### PR TITLE
Avoid freeing a NULL pointer

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -180,8 +180,6 @@ cron_schedule(PG_FUNCTION_ARGS)
 	parsedSchedule = parse_cron_entry(schedule);
 	if (parsedSchedule == NULL)
 	{
-		free_entry(parsedSchedule);
-
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 						errmsg("invalid schedule: %s", schedule)));
 	}


### PR DESCRIPTION
Fix a crash when passing an invalid schedule to cron.schedule, i.e. cron.schedule('foobar', $$SELECT 1$$)