### PR TITLE
Add an optional database argument to cron.schedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # src/test/modules/pg_cron/Makefile
 
 EXTENSION = pg_cron
-EXTVERSION = 1.0
+EXTVERSION = 1.1
 
 DATA_built = $(EXTENSION)--$(EXTVERSION).sql
 DATA = $(wildcard $(EXTENSION)--*--*.sql)
@@ -18,4 +18,6 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 $(EXTENSION)--1.0.sql: $(EXTENSION).sql $(EXTENSION)--0.1--1.0.sql
+	cat $^ > $@
+$(EXTENSION)--1.1.sql: $(EXTENSION).sql $(EXTENSION)--1.0--1.1.sql
 	cat $^ > $@

--- a/pg_cron--1.0--1.1.sql
+++ b/pg_cron--1.0--1.1.sql
@@ -1,0 +1,8 @@
+/* pg_cron--1.0--1.1.sql */
+
+CREATE FUNCTION cron.schedule(schedule text, command text, database text)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$cron_schedule$$;
+COMMENT ON FUNCTION cron.schedule(text,text,text)
+    IS 'schedule a pg_cron job in a specific database';

--- a/pg_cron.control
+++ b/pg_cron.control
@@ -1,4 +1,4 @@
 comment = 'Job scheduler for PostgreSQL'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/pg_cron'
 relocatable = false


### PR DESCRIPTION
After this change, `cron.schedule` lets you specify a database as a third, optional argument.

```
postgres=# SELECT cron.schedule('* * * * *', $$INSERT INTO test VALUES (1)$$, 'moo');
ERROR:  database "moo" does not exist
postgres=# CREATE DATABASE moo;
CREATE DATABASE
postgres=# SELECT cron.schedule('* * * * *', $$INSERT INTO test VALUES (1)$$, 'moo');
 schedule 
----------
       42
(1 row)
```

If the database is dropped after starting a job:
```
LOG:  cron job 7 starting: INSERT INTO test VALUES (1)
FATAL:  database "moo" does not exist
LOG:  cron job 7 connection failed
```

Fixes #13