### PR TITLE
Disable implicit fallthrough error in gcc-7 compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DATA = $(wildcard $(EXTENSION)--*--*.sql)
 # compilation configuration
 MODULE_big = $(EXTENSION)
 OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
-PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Iinclude -I$(libpq_srcdir)
+PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter  -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 


### PR DESCRIPTION
A user reported on slack that they can't compile pg-cron using gcc-7. This change in Makefile suppresses compilation error.