### PR TITLE
Porting fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DATA = $(wildcard $(EXTENSION)--*--*.sql)
 # compilation configuration
 MODULE_big = $(EXTENSION)
 OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
-PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter  -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
+PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-maybe-uninitialized -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -262,7 +262,7 @@ NextJobId(void)
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
-	jobId = DatumGetUInt32(jobIdDatum);
+	jobId = DatumGetInt64(jobIdDatum);
 
 	return jobId;
 }
@@ -351,7 +351,7 @@ cron_unschedule(PG_FUNCTION_ARGS)
 	if (!HeapTupleIsValid(heapTuple))
 	{
 		ereport(ERROR, (errmsg("could not find valid entry for job "
-							   UINT64_FORMAT, jobId)));
+							   INT64_FORMAT, jobId)));
 	}
 
 	/* check if the current user owns the row */
@@ -558,14 +558,14 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 
 	Assert(!HeapTupleHasNulls(heapTuple));
 
-	jobKey = DatumGetUInt32(jobId);
+	jobKey = DatumGetInt64(jobId);
 	job = hash_search(CronJobHash, &jobKey, HASH_ENTER, &isPresent);
 
-	job->jobId = DatumGetUInt32(jobId);
+	job->jobId = DatumGetInt64(jobId);
 	job->scheduleText = TextDatumGetCString(schedule);
 	job->command = TextDatumGetCString(command);
 	job->nodeName = TextDatumGetCString(nodeName);
-	job->nodePort = DatumGetUInt32(nodePort);
+	job->nodePort = DatumGetInt32(nodePort);
 	job->userName = TextDatumGetCString(userName);
 	job->database = TextDatumGetCString(database);
 
@@ -579,8 +579,8 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	}
 	else
 	{
-		ereport(LOG, (errmsg("invalid pg_cron schedule for job %ld: %s",
-							 jobId, job->scheduleText)));
+		ereport(LOG, (errmsg("invalid pg_cron schedule for job " INT64_FORMAT ": %s",
+							 job->jobId, job->scheduleText)));
 
 		/* a zeroed out schedule never runs */
 		memset(&job->schedule, 0, sizeof(entry));

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -912,7 +912,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			{
 				char *command = cronJob->command;
 
-				ereport(LOG, (errmsg("cron job %ld starting: %s",
+				ereport(LOG, (errmsg("cron job " INT64_FORMAT " starting: %s",
 									 jobId, command)));
 			}
 
@@ -1119,7 +1119,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 							char *cmdStatus = PQcmdStatus(result);
 							char *cmdTuples = PQcmdTuples(result);
 
-							ereport(LOG, (errmsg("cron job %ld completed: %s %s",
+							ereport(LOG, (errmsg("cron job " INT64_FORMAT " completed: %s %s",
 												 jobId, cmdStatus, cmdTuples)));
 						}
 
@@ -1165,7 +1165,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 							char *rowString = ngettext("row", "rows",
 													   tupleCount);
 
-							ereport(LOG, (errmsg("cron job %ld completed: "
+							ereport(LOG, (errmsg("cron job " INT64_FORMAT " completed: "
 												 "%d %s",
 												 jobId, tupleCount,
 												 rowString)));
@@ -1206,7 +1206,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 
 			if (task->errorMessage != NULL)
 			{
-				ereport(LOG, (errmsg("cron job %ld %s",
+				ereport(LOG, (errmsg("cron job " INT64_FORMAT " %s",
 									 jobId, task->errorMessage)));
 
 				if (task->freeErrorMessage)
@@ -1216,7 +1216,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			}
 			else
 			{
-				ereport(LOG, (errmsg("cron job %ld failed", jobId)));
+				ereport(LOG, (errmsg("cron job " INT64_FORMAT " failed", jobId)));
 			}
 
 			task->startDeadline = 0;


### PR DESCRIPTION
* Suppress warnings about maybe uninitialized variables in entry.c
* Correctly handle jobId as 64bit int

Spotted while building Debian packages for apt.postgresql.org.