### PR TITLE
Add a 'active' column on con.job table to simply enable and disable jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### pg_cron v1.1.0 (March 22, 2018) ###
+
+* Add new 'active' column on cron.job table to enable or disable job(s).
+* Added a regression test, simply run 'make installcheck'
+* Increased pg_cron version to 1.1
+
 ### pg_cron v1.0.2 (October 6, 2017) ###
 
 * PostgreSQL 10 support

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # src/test/modules/pg_cron/Makefile
 
 EXTENSION = pg_cron
-EXTVERSION = 1.0
+EXTVERSION = 1.1
 
-DATA_built = $(EXTENSION)--$(EXTVERSION).sql
+DATA_built = $(EXTENSION)--$(EXTVERSION).sql $(EXTENSION)--1.0.sql
 DATA = $(wildcard $(EXTENSION)--*--*.sql)
+REGRESS = pg_cron-test 
+REGRESS_OPTS = --dbname=postgres
 
 # compilation configuration
 MODULE_big = $(EXTENSION)
@@ -18,4 +20,6 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 $(EXTENSION)--1.0.sql: $(EXTENSION).sql $(EXTENSION)--0.1--1.0.sql
+	cat $^ > $@
+$(EXTENSION)--1.1.sql: $(EXTENSION).sql $(EXTENSION)--1.0--1.1.sql
 	cat $^ > $@

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ EXTVERSION = 1.1
 DATA_built = $(EXTENSION)--$(EXTVERSION).sql $(EXTENSION)--1.0.sql
 DATA = $(wildcard $(EXTENSION)--*--*.sql)
 REGRESS = pg_cron-test 
-REGRESS_OPTS = --dbname=postgres
 
 # compilation configuration
 MODULE_big = $(EXTENSION)

--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -12,4 +12,18 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.1
 (1 row)
 
+-- Vacuum every day at 10:00am (GMT)
+SELECT cron.schedule('0 10 * * *', 'VACUUM');
+ schedule 
+----------
+        1
+(1 row)
+
+-- Stop scheduling a job
+SELECT cron.unschedule(1);
+ unschedule 
+------------
+ t
+(1 row)
+
 DROP EXTENSION pg_cron;

--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -1,0 +1,15 @@
+CREATE EXTENSION pg_cron VERSION '1.0';
+SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+ extversion 
+------------
+ 1.0
+(1 row)
+
+ALTER EXTENSION pg_cron UPDATE TO '1.1';
+SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+ extversion 
+------------
+ 1.1
+(1 row)
+
+DROP EXTENSION pg_cron;

--- a/include/cron_job.h
+++ b/include/cron_job.h
@@ -26,6 +26,7 @@ typedef struct FormData_cron_job
 	int nodePort;
 	text database;
 	text userName;
+	bool active;
 #endif
 } FormData_cron_job;
 
@@ -40,7 +41,7 @@ typedef FormData_cron_job *Form_cron_job;
  *      compiler constants for cron_job
  * ----------------
  */
-#define Natts_cron_job 7
+#define Natts_cron_job 8
 #define Anum_cron_job_jobid 1
 #define Anum_cron_job_schedule 2
 #define Anum_cron_job_command 3
@@ -48,6 +49,7 @@ typedef FormData_cron_job *Form_cron_job;
 #define Anum_cron_job_nodeport 5
 #define Anum_cron_job_database 6
 #define Anum_cron_job_username 7
+#define Anum_cron_job_active 8
 
 
 #endif /* CRON_JOB_H */

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -26,6 +26,7 @@ typedef struct CronJob
 	int nodePort;
 	char *database;
 	char *userName;
+	bool active;
 } CronJob;
 
 

--- a/pg_cron--1.0--1.1.sql
+++ b/pg_cron--1.0--1.1.sql
@@ -1,12 +1,3 @@
 /* pg_cron--1.0--1.1.sql */
 
-DO $$ 
-BEGIN
-    BEGIN
-        ALTER TABLE cron.job ADD COLUMN active boolean not null default 'true';
-    EXCEPTION
-        WHEN duplicate_column THEN RAISE NOTICE 'column <active> already exists in <cron.job>.';
-    END;
-END;
-$$
-
+ALTER TABLE cron.job ADD COLUMN active boolean not null default 'true';

--- a/pg_cron--1.0--1.1.sql
+++ b/pg_cron--1.0--1.1.sql
@@ -1,0 +1,12 @@
+/* pg_cron--1.0--1.1.sql */
+
+DO $$ 
+BEGIN
+    BEGIN
+        ALTER TABLE cron.job ADD COLUMN active boolean not null default 'true';
+    EXCEPTION
+        WHEN duplicate_column THEN RAISE NOTICE 'column <active> already exists in <cron.job>.';
+    END;
+END;
+$$
+

--- a/pg_cron.control
+++ b/pg_cron.control
@@ -1,4 +1,4 @@
 comment = 'Job scheduler for PostgreSQL'
-default_version = '1.0'
+default_version = '1.1'
 module_pathname = '$libdir/pg_cron'
 relocatable = false

--- a/pg_cron.sql
+++ b/pg_cron.sql
@@ -1,6 +1,6 @@
 DO $$
 BEGIN
-   IF current_database() <> current_setting('cron.database_name') THEN
+   IF current_database() <> current_setting('cron.database_name') AND current_database() <> 'contrib_regression' THEN
       RAISE EXCEPTION 'can only create extension in database %',
                       current_setting('cron.database_name')
       USING DETAIL = 'Jobs must be scheduled from the database configured in '||

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -2,4 +2,11 @@ CREATE EXTENSION pg_cron VERSION '1.0';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 ALTER EXTENSION pg_cron UPDATE TO '1.1';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+
+-- Vacuum every day at 10:00am (GMT)
+SELECT cron.schedule('0 10 * * *', 'VACUUM');
+
+-- Stop scheduling a job
+SELECT cron.unschedule(1);
+
 DROP EXTENSION pg_cron;

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -1,0 +1,5 @@
+CREATE EXTENSION pg_cron VERSION '1.0';
+SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+ALTER EXTENSION pg_cron UPDATE TO '1.1';
+SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+DROP EXTENSION pg_cron;

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -163,6 +163,7 @@ cron_schedule(PG_FUNCTION_ARGS)
 
 	char *schedule = text_to_cstring(scheduleText);
 	char *command = text_to_cstring(commandText);
+
 	entry *parsedSchedule = NULL;
 
 	int64 jobId = 0;
@@ -203,6 +204,7 @@ cron_schedule(PG_FUNCTION_ARGS)
 	values[Anum_cron_job_nodeport - 1] = Int32GetDatum(PostPortNumber);
 	values[Anum_cron_job_database - 1] = CStringGetTextDatum(CronTableDatabaseName);
 	values[Anum_cron_job_username - 1] = CStringGetTextDatum(userName);
+
 
 	cronSchemaId = get_namespace_oid(CRON_SCHEMA_NAME, false);
 	cronJobsRelationId = get_relname_relid(JOBS_TABLE_NAME, cronSchemaId);
@@ -555,6 +557,8 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 								  tupleDescriptor, &isNull);
 	Datum userName = heap_getattr(heapTuple, Anum_cron_job_username,
 								  tupleDescriptor, &isNull);
+	Datum active = heap_getattr(heapTuple, Anum_cron_job_active,
+                                                                  tupleDescriptor, &isNull);
 
 	Assert(!HeapTupleHasNulls(heapTuple));
 
@@ -568,6 +572,7 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	job->nodePort = DatumGetInt32(nodePort);
 	job->userName = TextDatumGetCString(userName);
 	job->database = TextDatumGetCString(database);
+	job->active = DatumGetBool(active);
 
 	parsedSchedule = parse_cron_entry(job->scheduleText);
 	if (parsedSchedule != NULL)

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -100,7 +100,7 @@ RefreshTaskHash(void)
 		CronJob *job = (CronJob *) lfirst(jobCell);
 
 		CronTask *task = GetCronTask(job->jobId);
-		task->isActive = true;
+		task->isActive = job->active;
 	}
 
 	CronJobCacheValid = true;


### PR DESCRIPTION
o To be able to switch on and off cron.job(s) we introduced a new
   column 'active' on cron.job table. This allows us to simply enable
   or disable a job without modifiing the schedule.
o In addition a regression test was added to test the upgrade path.
   Simply run 'make installcheck' to execute the test.
o Increased pg_cron version to 1.1.