### PR TITLE
Changes for PostgreSQL 11

### DIFF
--- a/include/pg_cron.h
+++ b/include/pg_cron.h
@@ -14,6 +14,10 @@
 
 /* global settings */
 extern char *CronTableDatabaseName;
-
+#if (PG_VERSION_NUM < 110000)
+#define PgAllocSetContextCreate AllocSetContextCreate
+#else
+#define PgAllocSetContextCreate AllocSetContextCreateExtended
+#endif
 
 #endif

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -90,11 +90,11 @@ InitializeJobMetadataCache(void)
 	/* watch for invalidation events */
 	CacheRegisterRelcacheCallback(InvalidateJobCacheCallback, (Datum) 0);
 
-	CronJobContext = AllocSetContextCreate(CurrentMemoryContext,
-										   "pg_cron job context",
-										   ALLOCSET_DEFAULT_MINSIZE,
-										   ALLOCSET_DEFAULT_INITSIZE,
-										   ALLOCSET_DEFAULT_MAXSIZE);
+	CronJobContext = PgAllocSetContextCreate(CurrentMemoryContext,
+											 "pg_cron job context",
+											 ALLOCSET_DEFAULT_MINSIZE,
+											 ALLOCSET_DEFAULT_INITSIZE,
+											 ALLOCSET_DEFAULT_MAXSIZE);
 
 	CronJobHash = CreateCronJobHash();
 }
@@ -368,7 +368,12 @@ cron_unschedule(PG_FUNCTION_ARGS)
 												ACL_DELETE);
 		if (aclResult != ACLCHECK_OK)
 		{
-			aclcheck_error(aclResult, ACL_KIND_CLASS,
+			aclcheck_error(aclResult,
+#if (PG_VERSION_NUM < 110000)
+						   ACL_KIND_CLASS,
+#else
+						   OBJECT_TABLE,
+#endif
 						   get_rel_name(CronJobRelationId()));
 		}
 	}

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -239,7 +239,11 @@ PgCronWorkerMain(Datum arg)
 	BackgroundWorkerUnblockSignals();
 
 	/* Connect to our database */
+#if (PG_VERSION_NUM < 110000)
 	BackgroundWorkerInitializeConnection(CronTableDatabaseName, NULL);
+#else
+	BackgroundWorkerInitializeConnection(CronTableDatabaseName, NULL, 0);
+#endif
 
 	/* Make pg_cron recognisable in pg_stat_activity */
 	pgstat_report_appname("pg_cron scheduler");
@@ -266,12 +270,12 @@ PgCronWorkerMain(Datum arg)
 		MaxRunningTasks = 1;
 	}
 
-	CronLoopContext = AllocSetContextCreate(CurrentMemoryContext,
-											"pg_cron loop context",
-											ALLOCSET_DEFAULT_MINSIZE,
-											ALLOCSET_DEFAULT_INITSIZE,
-											ALLOCSET_DEFAULT_MAXSIZE);
 
+	CronLoopContext = PgAllocSetContextCreate(CurrentMemoryContext,
+											  "pg_cron loop context",
+											  ALLOCSET_DEFAULT_MINSIZE,
+											  ALLOCSET_DEFAULT_INITSIZE,
+											  ALLOCSET_DEFAULT_MAXSIZE);
 	InitializeJobMetadataCache();
 	InitializeTaskStateHash();
 

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -36,11 +36,11 @@ static HTAB *CronTaskHash = NULL;
 void
 InitializeTaskStateHash(void)
 {
-	CronTaskContext = AllocSetContextCreate(CurrentMemoryContext,
-											"pg_cron task context",
-											ALLOCSET_DEFAULT_MINSIZE,
-											ALLOCSET_DEFAULT_INITSIZE,
-											ALLOCSET_DEFAULT_MAXSIZE);
+	CronTaskContext = PgAllocSetContextCreate(CurrentMemoryContext,
+											  "pg_cron task context",
+											  ALLOCSET_DEFAULT_MINSIZE,
+											  ALLOCSET_DEFAULT_INITSIZE,
+											  ALLOCSET_DEFAULT_MAXSIZE);
 
 	CronTaskHash = CreateCronTaskHash();
 }


### PR DESCRIPTION
- AllocSetContextCreate() becomes AllocSetContextCreateExtended().
- ACL_KIND_CLASS replaced by OBJECT_TABLE in aclcheck_error().
- BackgroundWorkerInitializeConnection() takes a new flag parameter.