### PR TITLE
Add -Wno-unknown-warning-option to gcc PG_CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REGRESS = pg_cron-test
 MODULE_big = $(EXTENSION)
 OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 ifeq ($(CC),gcc)
-    PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-maybe-uninitialized -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
+    PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unknown-warning-option -Wno-unused-parameter -Wno-maybe-uninitialized -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 else
     PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 endif


### PR DESCRIPTION
Commit 01e249b0a71 made -Wno-maybe-uninitialized in PG_CPPFLAGS depend
on whether gcc is used for compilation. With PG 11 and JIT enabled, that
is however not enough, because even with CC=gcc, the same PG_CPPFLAGS
are used with clang for producing the .bc bitcode files. Fix by removing
-Werror and hence making unknown clang flags non-fatal.