### PR TITLE
Try to fix issue #63

### DIFF
--- a/include/pg_cron.h
+++ b/include/pg_cron.h
@@ -14,7 +14,7 @@
 
 /* global settings */
 extern char *CronTableDatabaseName;
-#if (PG_VERSION_NUM < 110000)
+#if (PG_VERSION_NUM < 110000) || (PG_VERSION_NUM >= 120000)
 #define PgAllocSetContextCreate AllocSetContextCreate
 #else
 #define PgAllocSetContextCreate AllocSetContextCreateExtended

--- a/include/pg_cron.h
+++ b/include/pg_cron.h
@@ -14,10 +14,6 @@
 
 /* global settings */
 extern char *CronTableDatabaseName;
-#if (PG_VERSION_NUM < 110000) || (PG_VERSION_NUM >= 120000)
 #define PgAllocSetContextCreate AllocSetContextCreate
-#else
-#define PgAllocSetContextCreate AllocSetContextCreateExtended
-#endif
 
 #endif


### PR DESCRIPTION
When more than `cron.max_running_jobs` jobs were waiting to run, it could happen that all available slots in "pollFDs" were taken up by waiting jobs with `pendingRunCount` > 0 that did nothing (polled for file descriptor -1).

These then &ldquo;crowded out&rdquo; other jobs that were running, so that their sockets never got polled and we never detected that they are done.

In that case, pg_cron would repeat this &ldquo;no-op&rdquo; pull indefinitely, causing a hang.

The typical symptom is a number of open database connections that are idle, because their job is done.

In passing, refactor the code to make it more readable.

The essence of this patch is to remove the second condition from

    if (task->state == CRON_TASK_WAITING && task->pendingRunCount == 0)
     {
        /* don't poll idle tasks */
        continue;
    }

and to avoid polling a file descriptor of -1 for good.