### PR TITLE
Make pg_cron compile for Windows using Visual Studio 

### DIFF
--- a/include/cron.h
+++ b/include/cron.h
@@ -39,6 +39,10 @@
 # include <time.h>
 #endif
 
+#ifdef _MSC_VER
+#include "winCompat.h"
+#endif
+
 	/* these are really immutable, and are
 	 *   defined for symbolic convenience only
 	 * TRUE, FALSE, and ERR must be distinct

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -35,10 +35,10 @@ extern bool CronJobCacheValid;
 
 
 /* functions for retrieving job metadata */
-extern void InitializeJobMetadataCache(void);
-extern void ResetJobMetadataCache(void);
-extern List * LoadCronJobList(void);
-extern CronJob * GetCronJob(int64 jobId);
+PGDLLEXPORT extern void InitializeJobMetadataCache(void);
+PGDLLEXPORT extern void ResetJobMetadataCache(void);
+PGDLLEXPORT extern List * LoadCronJobList(void);
+PGDLLEXPORT extern CronJob * GetCronJob(int64 jobId);
 
 
 #endif

--- a/include/poll.h
+++ b/include/poll.h
@@ -1,0 +1,14 @@
+#ifndef SYS_POLL_H
+#define SYS_POLL_H
+typedef int nfds_t;
+/*
+struct pollfd
+{
+	int fd;
+	short events;
+	short revents;
+};
+*/
+int poll(struct pollfd fds[], nfds_t nfds, int timeout);
+
+#endif /* SYS_POLL_H */

--- a/include/task_states.h
+++ b/include/task_states.h
@@ -34,7 +34,7 @@ typedef struct CronTask
 	int64 jobId;
 	int64 runId;
 	CronTaskState state;
-	uint pendingRunCount;
+	unsigned int pendingRunCount;
 	PGconn *connection;
 	PostgresPollingStatusType pollingStatus;
 	TimestampTz startDeadline;

--- a/include/task_states.h
+++ b/include/task_states.h
@@ -34,7 +34,7 @@ typedef struct CronTask
 	int64 jobId;
 	int64 runId;
 	CronTaskState state;
-	unsigned int pendingRunCount;
+	uint32 pendingRunCount;
 	PGconn *connection;
 	PostgresPollingStatusType pollingStatus;
 	TimestampTz startDeadline;

--- a/include/task_states.h
+++ b/include/task_states.h
@@ -45,11 +45,11 @@ typedef struct CronTask
 } CronTask;
 
 
-extern void InitializeTaskStateHash(void);
-extern void RefreshTaskHash(void);
-extern List * CurrentTaskList(void);
-extern void InitializeCronTask(CronTask *task, int64 jobId);
-extern void RemoveTask(int64 jobId);
+PGDLLEXPORT extern void InitializeTaskStateHash(void);
+PGDLLEXPORT extern void RefreshTaskHash(void);
+PGDLLEXPORT extern List * CurrentTaskList(void);
+PGDLLEXPORT extern void InitializeCronTask(CronTask *task, int64 jobId);
+PGDLLEXPORT extern void RemoveTask(int64 jobId);
 
 
 #endif

--- a/include/winCompat.h
+++ b/include/winCompat.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifndef WINDOWS_INCLUDED
+#define WINDOWS_INCLUDED
+
+#if defined(WIN32) || defined(WIN64) 
+	#define snprintf _snprintf 
+	#define vsnprintf _vsnprintf 
+	#define strcasecmp _stricmp 
+	#define strncasecmp _strnicmp 
+	#define uint unsigned int
+	
+#endif
+
+typedef int uid_t;
+typedef int gid_t;
+
+
+#endif /* Ndef WINDOWS_INCLUDED */
+
+

--- a/src/entry.c
+++ b/src/entry.c
@@ -77,7 +77,7 @@ parse_cron_entry(char *schedule)
 	entry *e = NULL;
 	int	ch = 0;
 	char cmd[MAX_COMMAND];
-	file_buffer buffer = {{},0,0,{},0};
+	file_buffer buffer = {{0},0,0,{0},0};
 	FILE *file = (FILE *) &buffer;
 
 	int scheduleLength = strlen(schedule); 

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -72,6 +72,9 @@ PG_FUNCTION_INFO_V1(cron_schedule);
 PG_FUNCTION_INFO_V1(cron_unschedule);
 PG_FUNCTION_INFO_V1(cron_job_cache_invalidate);
 
+PGDLLEXPORT Datum cron_schedule(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum cron_unschedule(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum cron_job_cache_invalidate(PG_FUNCTION_ARGS);
 
 /* global variables */
 static MemoryContext CronJobContext = NULL;

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -67,14 +67,14 @@ static CronJob * TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple);
 static bool PgCronHasBeenLoaded(void);
 
 
+PGDLLEXPORT Datum cron_schedule(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum cron_unschedule(PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum cron_job_cache_invalidate(PG_FUNCTION_ARGS);
+
 /* SQL-callable functions */
 PG_FUNCTION_INFO_V1(cron_schedule);
 PG_FUNCTION_INFO_V1(cron_unschedule);
 PG_FUNCTION_INFO_V1(cron_job_cache_invalidate);
-
-PGDLLEXPORT Datum cron_schedule(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum cron_unschedule(PG_FUNCTION_ARGS);
-PGDLLEXPORT Datum cron_job_cache_invalidate(PG_FUNCTION_ARGS);
 
 /* global variables */
 static MemoryContext CronJobContext = NULL;

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -83,11 +83,11 @@ typedef enum
 
 
 /* forward declarations */
-void _PG_init(void);
-void _PG_fini(void);
+PGDLLEXPORT void _PG_init(void);
+PGDLLEXPORT void _PG_fini(void);
 static void pg_cron_sigterm(SIGNAL_ARGS);
 static void pg_cron_sighup(SIGNAL_ARGS);
-void PgCronWorkerMain(Datum arg);
+PGDLLEXPORT void PgCronWorkerMain(Datum arg);
 
 static void StartAllPendingRuns(List *taskList, TimestampTz currentTime);
 static void StartPendingRuns(CronTask *task, ClockProgress clockProgress,

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -130,7 +130,7 @@ GetCronTask(int64 jobId)
 /*
  * InitializeCronTask intializes a CronTask struct.
  */
-void
+PGDLLEXPORT void
 InitializeCronTask(CronTask *task, int64 jobId)
 {
 	task->runId = 0;


### PR DESCRIPTION
uint is as far as I can tell not a standard data-type. Visual Studio does not like it, and will not compile the code. I think that unsigned int should be asuitable replacement. 

This is preparation for additional work to get pg_cron running on Windows. 