### PR TITLE
Call AllocSetContextCreate() directly rather than through a macro.

### DIFF
--- a/include/pg_cron.h
+++ b/include/pg_cron.h
@@ -14,10 +14,5 @@
 
 /* global settings */
 extern char *CronTableDatabaseName;
-#if (PG_VERSION_NUM < 110000)
-#define PgAllocSetContextCreate AllocSetContextCreate
-#else
-#define PgAllocSetContextCreate AllocSetContextCreateExtended
-#endif
 
 #endif

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -91,7 +91,7 @@ InitializeJobMetadataCache(void)
 	/* watch for invalidation events */
 	CacheRegisterRelcacheCallback(InvalidateJobCacheCallback, (Datum) 0);
 
-	CronJobContext = PgAllocSetContextCreate(CurrentMemoryContext,
+	CronJobContext = AllocSetContextCreate(CurrentMemoryContext,
 											 "pg_cron job context",
 											 ALLOCSET_DEFAULT_MINSIZE,
 											 ALLOCSET_DEFAULT_INITSIZE,

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -288,7 +288,7 @@ PgCronWorkerMain(Datum arg)
 	}
 
 
-	CronLoopContext = PgAllocSetContextCreate(CurrentMemoryContext,
+	CronLoopContext = AllocSetContextCreate(CurrentMemoryContext,
 											  "pg_cron loop context",
 											  ALLOCSET_DEFAULT_MINSIZE,
 											  ALLOCSET_DEFAULT_INITSIZE,

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -36,7 +36,7 @@ static HTAB *CronTaskHash = NULL;
 void
 InitializeTaskStateHash(void)
 {
-	CronTaskContext = PgAllocSetContextCreate(CurrentMemoryContext,
+	CronTaskContext = AllocSetContextCreate(CurrentMemoryContext,
 											  "pg_cron task context",
 											  ALLOCSET_DEFAULT_MINSIZE,
 											  ALLOCSET_DEFAULT_INITSIZE,


### PR DESCRIPTION
The macro was needed with early PostgreSQL versions in the 11.x
branch that introduced AllocSetContextCreateExtended().
Later this was simplified (see commit 13cd7209 in Postgres)
and starting with 12.x we must call AllocSetContextCreate()
again.