### PR TITLE
Allow jobs to be scheduled by name

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -5,11 +5,11 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.0
 (1 row)
 
-ALTER EXTENSION pg_cron UPDATE TO '1.1';
+ALTER EXTENSION pg_cron UPDATE TO '1.3';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  extversion 
 ------------
- 1.1
+ 1.3
 (1 row)
 
 -- Vacuum every day at 10:00am (GMT)
@@ -36,6 +36,61 @@ SELECT cron.schedule('@restart', 'ALTER EXTENSION pg_cron UPDATE');
  schedule 
 ----------
         2
+(1 row)
+
+-- Vacuum every day at 10:00am (GMT)
+SELECT cron.schedule('myvacuum', '0 10 * * *', 'VACUUM');
+ schedule 
+----------
+        3
+(1 row)
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+ jobid | jobname  |  schedule  |            command             
+-------+----------+------------+--------------------------------
+     2 |          | @restart   | ALTER EXTENSION pg_cron UPDATE
+     3 | myvacuum | 0 10 * * * | VACUUM
+(2 rows)
+
+-- Make that 11:00am (GMT)
+SELECT cron.schedule('myvacuum', '0 11 * * *', 'VACUUM');
+ schedule 
+----------
+        3
+(1 row)
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+ jobid | jobname  |  schedule  |            command             
+-------+----------+------------+--------------------------------
+     2 |          | @restart   | ALTER EXTENSION pg_cron UPDATE
+     3 | myvacuum | 0 11 * * * | VACUUM
+(2 rows)
+
+-- Make that VACUUM FULL
+SELECT cron.schedule('myvacuum', '0 11 * * *', 'VACUUM FULL');
+ schedule 
+----------
+        3
+(1 row)
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+ jobid | jobname  |  schedule  |            command             
+-------+----------+------------+--------------------------------
+     2 |          | @restart   | ALTER EXTENSION pg_cron UPDATE
+     3 | myvacuum | 0 11 * * * | VACUUM FULL
+(2 rows)
+
+-- Stop scheduling a job
+SELECT cron.unschedule('myvacuum');
+ unschedule 
+------------
+ t
+(1 row)
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+ jobid | jobname | schedule |            command             
+-------+---------+----------+--------------------------------
+     2 |         | @restart | ALTER EXTENSION pg_cron UPDATE
 (1 row)
 
 DROP EXTENSION pg_cron;

--- a/include/cron_job.h
+++ b/include/cron_job.h
@@ -27,6 +27,7 @@ typedef struct FormData_cron_job
 	text database;
 	text userName;
 	bool active;
+	Name jobName;
 #endif
 } FormData_cron_job;
 
@@ -41,7 +42,7 @@ typedef FormData_cron_job *Form_cron_job;
  *      compiler constants for cron_job
  * ----------------
  */
-#define Natts_cron_job 8
+#define Natts_cron_job 9
 #define Anum_cron_job_jobid 1
 #define Anum_cron_job_schedule 2
 #define Anum_cron_job_command 3
@@ -50,6 +51,7 @@ typedef FormData_cron_job *Form_cron_job;
 #define Anum_cron_job_database 6
 #define Anum_cron_job_username 7
 #define Anum_cron_job_active 8
+#define Anum_cron_job_jobname 9
 
 typedef struct FormData_job_run_details
 {

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -39,6 +39,7 @@ typedef struct CronJob
 	char *database;
 	char *userName;
 	bool active;
+	Name jobName;
 } CronJob;
 
 

--- a/pg_cron--1.2--1.3.sql
+++ b/pg_cron--1.2--1.3.sql
@@ -20,3 +20,19 @@ CREATE POLICY cron_job_run_details_policy ON cron.job_run_details USING (usernam
 
 SELECT pg_catalog.pg_extension_config_dump('cron.job_run_details', '');
 SELECT pg_catalog.pg_extension_config_dump('cron.runid_seq', '');
+
+ALTER TABLE cron.job ADD COLUMN jobname name UNIQUE;
+
+CREATE FUNCTION cron.schedule(job_name name, schedule text, command text)
+    RETURNS bigint
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$cron_schedule_named$$;
+COMMENT ON FUNCTION cron.schedule(name,text,text)
+    IS 'schedule a pg_cron job';
+
+CREATE FUNCTION cron.unschedule(job_name name)
+    RETURNS bool
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$cron_unschedule_named$$;
+COMMENT ON FUNCTION cron.unschedule(name)
+    IS 'unschedule a pg_cron job';

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION pg_cron VERSION '1.0';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
-ALTER EXTENSION pg_cron UPDATE TO '1.1';
+ALTER EXTENSION pg_cron UPDATE TO '1.3';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 
 -- Vacuum every day at 10:00am (GMT)
@@ -9,11 +9,32 @@ SELECT cron.schedule('0 10 * * *', 'VACUUM');
 -- Stop scheduling a job
 SELECT cron.unschedule(1);
 
+
 -- Invalid input: input too long
 SELECT cron.schedule(repeat('a', 1000), '');
 
 -- Try to update pg_cron on restart
 SELECT cron.schedule('@restar', 'ALTER EXTENSION pg_cron UPDATE');
 SELECT cron.schedule('@restart', 'ALTER EXTENSION pg_cron UPDATE');
+
+-- Vacuum every day at 10:00am (GMT)
+SELECT cron.schedule('myvacuum', '0 10 * * *', 'VACUUM');
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+
+-- Make that 11:00am (GMT)
+SELECT cron.schedule('myvacuum', '0 11 * * *', 'VACUUM');
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+
+-- Make that VACUUM FULL
+SELECT cron.schedule('myvacuum', '0 11 * * *', 'VACUUM FULL');
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+
+-- Stop scheduling a job
+SELECT cron.unschedule('myvacuum');
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
 
 DROP EXTENSION pg_cron;


### PR DESCRIPTION
Adds a jobname column and new schedule/unschedule definitions that take a name instead of a job ID.

Fixes #24 