### PR TITLE
Fix installation instructions for PostgreSQL 9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ After restarting PostgreSQL, you can create the pg_cron functions and metadata t
 -- run as superuser:
 CREATE EXTENSION pg_cron;
 
+-- on PostgreSQL 9.x, do this instead:
+CREATE EXTENSION pg_cron VERSION '1.0';
+ALTER EXTENSION pg_cron UPDATE;
+
 -- optionally, grant usage to regular users:
 GRANT USAGE ON SCHEMA cron TO marco;
 ```


### PR DESCRIPTION
Versions before 10 can't directly install version 1.2 which only exists
as 1.0 -> 1.1 -> 1.2 upgrade path.

Spotted by the Debian regression tests.