### PR TITLE
adding support for using background workers instead of libpq + adding support for an audit table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # src/test/modules/pg_cron/Makefile
 
 EXTENSION = pg_cron
-EXTVERSION = 1.2
+EXTVERSION = 1.3
 
 DATA_built = $(EXTENSION)--1.0.sql
 DATA = $(wildcard $(EXTENSION)--*--*.sql)

--- a/include/cron_job.h
+++ b/include/cron_job.h
@@ -51,5 +51,34 @@ typedef FormData_cron_job *Form_cron_job;
 #define Anum_cron_job_username 7
 #define Anum_cron_job_active 8
 
+typedef struct FormData_job_run_details
+{
+	int64 jobId;
+	int64 runId;
+	int32 job_pid;
+#ifdef CATALOG_VARLEN
+	text database;
+	text username;
+	text command;
+	text status;
+	text return_message;
+	timestamptz start_time;
+	timestamptz end_time;
+#endif
+} FormData_job_run_details;
+
+typedef FormData_job_run_details *Form_job_run_details;
+
+#define Natts_job_run_details 10
+#define Anum_job_run_details_jobid 1
+#define Anum_job_run_details_runid 2
+#define Anum_job_run_details_job_pid 3
+#define Anum_job_run_details_database 4
+#define Anum_job_run_details_username 5
+#define Anum_job_run_details_command 6
+#define Anum_job_run_details_status 7
+#define Anum_job_run_details_return_message 8
+#define Anum_job_run_details_start_time 9
+#define Anum_job_run_details_end_time 10
 
 #endif /* CRON_JOB_H */

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -44,5 +44,11 @@ extern void ResetJobMetadataCache(void);
 extern List * LoadCronJobList(void);
 extern CronJob * GetCronJob(int64 jobId);
 
+extern bool InsertOrUpdateJobRunDetail(int64 runId, int64 *jobId, int32 *job_pid,
+									char *database, char *username, char *command,
+									char *status, char *return_message, TimestampTz *start_time,
+									TimestampTz *end_time);
+extern int64 NextRunId(void);
+extern void CleanAuditTable(void);
 
 #endif

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -17,6 +17,15 @@
 #include "datatype/timestamp.h"
 #endif
 
+typedef enum
+{
+	CRON_STATUS_STARTING,
+	CRON_STATUS_RUNNING,
+	CRON_STATUS_SENDING,
+	CRON_STATUS_CONNECTING,
+	CRON_STATUS_SUCCEEDED,
+	CRON_STATUS_FAILED
+} CronStatus;
 
 /* job metadata data structure */
 typedef struct CronJob
@@ -44,11 +53,11 @@ extern void ResetJobMetadataCache(void);
 extern List * LoadCronJobList(void);
 extern CronJob * GetCronJob(int64 jobId);
 
-extern bool InsertOrUpdateJobRunDetail(int64 runId, int64 *jobId, int32 *job_pid,
-									char *database, char *username, char *command,
-									char *status, char *return_message, TimestampTz *start_time,
+extern void InsertJobRunDetail(int64 runId, int64 *jobId, char *database, char *username, char *command, char *status);
+extern void UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_message, TimestampTz *start_time,
 									TimestampTz *end_time);
 extern int64 NextRunId(void);
-extern void CleanAuditTable(void);
+extern void MarkPendingRunsAsFailed(void);
+extern char *GetCronStatus(CronStatus cronstatus);
 
 #endif

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -13,6 +13,9 @@
 
 
 #include "nodes/pg_list.h"
+#if (PG_VERSION_NUM < 120000)
+#include "datatype/timestamp.h"
+#endif
 
 
 /* job metadata data structure */

--- a/include/task_states.h
+++ b/include/task_states.h
@@ -14,6 +14,8 @@
 
 #include "job_metadata.h"
 #include "libpq-fe.h"
+#include "postmaster/bgworker.h"
+#include "storage/dsm.h"
 #include "utils/timestamp.h"
 
 
@@ -26,8 +28,16 @@ typedef enum
 	CRON_TASK_RUNNING = 4,
 	CRON_TASK_RECEIVING = 5,
 	CRON_TASK_DONE = 6,
-	CRON_TASK_ERROR = 7
+	CRON_TASK_ERROR = 7,
+	CRON_TASK_BGW_START = 8,
+	CRON_TASK_BGW_RUNNING = 9
 } CronTaskState;
+
+struct BackgroundWorkerHandle
+{
+	int slot;
+	uint64 generation;
+};
 
 typedef struct CronTask
 {
@@ -42,6 +52,8 @@ typedef struct CronTask
 	bool isActive;
 	char *errorMessage;
 	bool freeErrorMessage;
+	dsm_segment *seg;
+	BackgroundWorkerHandle handle;
 } CronTask;
 
 

--- a/pg_cron--1.2--1.3.sql
+++ b/pg_cron--1.2--1.3.sql
@@ -1,0 +1,22 @@
+/* pg_cron--1.2--1.3.sql */
+
+CREATE SEQUENCE cron.runid_seq;
+CREATE TABLE cron.job_run_details (
+	jobid bigint,
+	runid bigint primary key default nextval('cron.runid_seq'),
+	job_pid integer,
+	database text,
+	username text,
+	command text,
+	status text,
+	return_message text,
+	start_time timestamptz,
+	end_time timestamptz
+);
+
+GRANT SELECT ON cron.job_run_details TO public;
+ALTER TABLE cron.job_run_details ENABLE ROW LEVEL SECURITY;
+CREATE POLICY cron_job_run_details_policy ON cron.job_run_details USING (username = current_user);
+
+SELECT pg_catalog.pg_extension_config_dump('cron.job_run_details', '');
+SELECT pg_catalog.pg_extension_config_dump('cron.runid_seq', '');

--- a/pg_cron.control
+++ b/pg_cron.control
@@ -1,4 +1,4 @@
 comment = 'Job scheduler for PostgreSQL'
-default_version = '1.2'
+default_version = '1.3'
 module_pathname = '$libdir/pg_cron'
 relocatable = false

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -3,6 +3,9 @@
  * src/pg_cron.c
  *
  * Implementation of the pg_cron task scheduler.
+ * Wording:
+ *	   - A job is a scheduling definition of a task
+ *	   - A task is what is actually executed within the database engine
  *
  * Copyright (c) 2016, Citus Data, Inc.
  *

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -20,6 +20,8 @@
 #include "storage/latch.h"
 #include "storage/lwlock.h"
 #include "storage/proc.h"
+#include "storage/shm_mq.h"
+#include "storage/shm_toc.h"
 #include "storage/shmem.h"
 
 /* these headers are used by this particular worker's code */
@@ -39,19 +41,23 @@
 #include "access/genam.h"
 #include "access/heapam.h"
 #include "access/htup_details.h"
+#include "access/printtup.h"
 #include "access/xact.h"
 #include "access/xlog.h"
 #include "catalog/pg_extension.h"
 #include "catalog/indexing.h"
 #include "catalog/namespace.h"
+#include "commands/async.h"
 #include "commands/dbcommands.h"
 #include "commands/extension.h"
 #include "commands/sequence.h"
 #include "commands/trigger.h"
 #include "lib/stringinfo.h"
 #include "libpq-fe.h"
+#include "libpq/pqmq.h"
 #include "libpq/pqsignal.h"
 #include "mb/pg_wchar.h"
+#include "parser/analyze.h"
 #include "pgstat.h"
 #include "postmaster/postmaster.h"
 #include "utils/builtins.h"
@@ -59,18 +65,31 @@
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/portal.h"
+#include "utils/ps_status.h"
 #include "utils/rel.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
+#include "utils/timeout.h"
 #include "utils/timestamp.h"
 #if (PG_VERSION_NUM >= 100000)
 #include "utils/varlena.h"
 #endif
+#include "tcop/pquery.h"
 #include "tcop/utility.h"
+#include "libpq/pqformat.h"
 
 
 PG_MODULE_MAGIC;
 
+
+/* Table-of-contents constants for our dynamic shared memory segment. */
+#define PG_CRON_MAGIC			0x51028080
+#define PG_CRON_KEY_DATABASE	0
+#define PG_CRON_KEY_USERNAME	1
+#define PG_CRON_KEY_COMMAND		2
+#define PG_CRON_KEY_QUEUE		3
+#define PG_CRON_NKEYS			4
 
 /* ways in which the clock can change between main loop iterations */
 typedef enum
@@ -81,13 +100,14 @@ typedef enum
 	CLOCK_CHANGE = 3
 } ClockProgress;
 
-
 /* forward declarations */
 void _PG_init(void);
 void _PG_fini(void);
 static void pg_cron_sigterm(SIGNAL_ARGS);
 static void pg_cron_sighup(SIGNAL_ARGS);
+static void pg_cron_background_worker_sigterm(SIGNAL_ARGS);
 void PgCronWorkerMain(Datum arg);
+void CronBackgroundWorker(Datum arg);
 
 static void StartAllPendingRuns(List *taskList, TimestampTz currentTime);
 static void StartPendingRuns(CronTask *task, ClockProgress clockProgress,
@@ -104,7 +124,12 @@ static void PollForTasks(List *taskList);
 static bool CanStartTask(CronTask *task);
 static void ManageCronTasks(List *taskList, TimestampTz currentTime);
 static void ManageCronTask(CronTask *task, TimestampTz currentTime);
+static void ExecuteSqlString(const char *sql);
+static void GetTaskFeedback(shm_mq_handle *responseq, PGresult *result, CronTask *task);
 
+static bool jobCanceled(CronTask *task);
+static bool jobStartupTimeout(CronTask *task, TimestampTz currentTime);
+static char* pg_cron_cmdTuples(char *msg);
 
 /* global settings */
 char *CronTableDatabaseName = "postgres";
@@ -120,6 +145,7 @@ static const int MaxWait = 1000; /* maximum time in ms that poll() can block */
 static bool RebootJobsScheduled = false;
 static int RunningTaskCount = 0;
 static int MaxRunningTasks = 0;
+static bool UseBackgroundWorkers = false;
 
 
 /*
@@ -177,9 +203,19 @@ _PG_init(void)
 	DefineCustomStringVariable(
 		"cron.host",
 		gettext_noop("Hostname to connect to postgres."),
-		NULL,
+		gettext_noop("This setting has no effect when background workers are used."),
 		&CronHost,
 		"localhost",
+		PGC_POSTMASTER,
+		GUC_SUPERUSER_ONLY,
+		NULL, NULL, NULL);
+
+	DefineCustomBoolVariable(
+		"cron.use_background_workers",
+		gettext_noop("Use background workers instead of client sessions."),
+		NULL,
+		&UseBackgroundWorkers,
+		false,
 		PGC_POSTMASTER,
 		GUC_SUPERUSER_ONLY,
 		NULL, NULL, NULL);
@@ -234,6 +270,86 @@ pg_cron_sighup(SIGNAL_ARGS)
 	{
 		SetLatch(&MyProc->procLatch);
 	}
+}
+
+/*
+ * pg_cron_cmdTuples -
+ *      mainly copy/pasted from PQcmdTuples
+ *      If the last command was INSERT/UPDATE/DELETE/MOVE/FETCH/COPY, return
+ *      a string containing the number of inserted/affected tuples. If not,
+ *      return "".
+ *
+ *      XXX: this should probably return an int
+ */
+
+static char *
+pg_cron_cmdTuples(char *msg)
+{
+        char       *p,
+                           *c;
+
+        if (!msg)
+                return "";
+
+        if (strncmp(msg, "INSERT ", 7) == 0)
+        {
+                p = msg + 7;
+                /* INSERT: skip oid and space */
+                while (*p && *p != ' ')
+                        p++;
+                if (*p == 0)
+                        goto interpret_error;   /* no space? */
+                p++;
+        }
+        else if (strncmp(msg, "SELECT ", 7) == 0 ||
+                         strncmp(msg, "DELETE ", 7) == 0 ||
+                         strncmp(msg, "UPDATE ", 7) == 0)
+                p = msg + 7;
+        else if (strncmp(msg, "FETCH ", 6) == 0)
+                p = msg + 6;
+        else if (strncmp(msg, "MOVE ", 5) == 0 ||
+                         strncmp(msg, "COPY ", 5) == 0)
+                p = msg + 5;
+        else
+                return "";
+
+        /* check that we have an integer (at least one digit, nothing else) */
+        for (c = p; *c; c++)
+        {
+                if (!isdigit((unsigned char) *c))
+                        goto interpret_error;
+        }
+        if (c == p)
+                goto interpret_error;
+
+        return p;
+
+interpret_error:
+	ereport(LOG, (errmsg("could not interpret result from server: %s", msg)));
+        return "";
+}
+
+/*
+ * Signal handler for SIGTERM for background workers
+ * 		When we receive a SIGTERM, we set InterruptPending and ProcDiePending
+ * 		just like a normal backend.  The next CHECK_FOR_INTERRUPTS() will do the
+ * 		right thing.
+ */
+static void
+pg_cron_background_worker_sigterm(SIGNAL_ARGS)
+{
+	int save_errno = errno;
+
+	if (MyProc)
+		SetLatch(&MyProc->procLatch);
+
+	if (!proc_exit_inprogress)
+	{
+		InterruptPending = true;
+		ProcDiePending = true;
+	}
+
+	errno = save_errno;
 }
 
 
@@ -751,6 +867,7 @@ PollForTasks(List *taskList)
 
 		if (task->state == CRON_TASK_CONNECTING ||
 			task->state == CRON_TASK_SENDING ||
+			task->state == CRON_TASK_BGW_RUNNING ||
 			task->state == CRON_TASK_RUNNING)
 		{
 			PGconn *connection = task->connection;
@@ -908,70 +1025,206 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 
 			task->runId = RunCount++;
 			task->pendingRunCount -= 1;
-			task->state = CRON_TASK_START;
+			if (UseBackgroundWorkers)
+				task->state = CRON_TASK_BGW_START;
+			else
+				task->state = CRON_TASK_START;
 
 			RunningTaskCount++;
 		}
 
 		case CRON_TASK_START:
 		{
-			const char *clientEncoding = GetDatabaseEncodingName();
-			char nodePortString[12];
-			TimestampTz startDeadline = 0;
-
-			const char *keywordArray[] = {
-				"host",
-				"port",
-				"fallback_application_name",
-				"client_encoding",
-				"dbname",
-				"user",
-				NULL
-			};
-			const char *valueArray[] = {
-				cronJob->nodeName,
-				nodePortString,
-				"pg_cron",
-				clientEncoding,
-				cronJob->database,
-				cronJob->userName,
-				NULL
-			};
-			sprintf(nodePortString, "%d", cronJob->nodePort);
-
-			Assert(sizeof(keywordArray) == sizeof(valueArray));
-
-			if (CronLogStatement)
+			/* as there is no break at the end of the previous case
+			 * to not add an extra second, then do another check here
+			 */
+			if (!UseBackgroundWorkers)
 			{
-				char *command = cronJob->command;
+				const char *clientEncoding = GetDatabaseEncodingName();
+				char nodePortString[12];
+				TimestampTz startDeadline = 0;
 
-				ereport(LOG, (errmsg("cron job " INT64_FORMAT " starting: %s",
+				const char *keywordArray[] = {
+					"host",
+					"port",
+					"fallback_application_name",
+					"client_encoding",
+					"dbname",
+					"user",
+					NULL
+					};
+				const char *valueArray[] = {
+					cronJob->nodeName,
+					nodePortString,
+					"pg_cron",
+					clientEncoding,
+					cronJob->database,
+					cronJob->userName,
+					NULL
+				};
+				sprintf(nodePortString, "%d", cronJob->nodePort);
+
+				Assert(sizeof(keywordArray) == sizeof(valueArray));
+
+				if (CronLogStatement)
+				{
+					char *command = cronJob->command;
+
+					ereport(LOG, (errmsg("cron job " INT64_FORMAT " starting: %s",
 									 jobId, command)));
-			}
+				}
 
-			connection = PQconnectStartParams(keywordArray, valueArray, false);
-			PQsetnonblocking(connection, 1);
+				connection = PQconnectStartParams(keywordArray, valueArray, false);
+				PQsetnonblocking(connection, 1);
 
-			connectionStatus = PQstatus(connection);
-			if (connectionStatus == CONNECTION_BAD)
-			{
-				/* make sure we call PQfinish on the connection */
+				connectionStatus = PQstatus(connection);
+				if (connectionStatus == CONNECTION_BAD)
+				{
+					/* make sure we call PQfinish on the connection */
+					task->connection = connection;
+
+					task->errorMessage = "connection failed";
+					task->pollingStatus = 0;
+					task->state = CRON_TASK_ERROR;
+					break;
+				}
+
+				startDeadline = TimestampTzPlusMilliseconds(currentTime,
+											CronTaskStartTimeout);
+
+				task->startDeadline = startDeadline;
 				task->connection = connection;
+				task->pollingStatus = PGRES_POLLING_WRITING;
+				task->state = CRON_TASK_CONNECTING;
+				break;
+			}
+		}
 
-				task->errorMessage = "connection failed";
-				task->pollingStatus = 0;
+		case CRON_TASK_BGW_START:
+		{
+
+			BackgroundWorker worker;
+			pid_t pid;
+			shm_toc_estimator e;
+			shm_toc *toc;
+			char *database;
+			char *username;
+			char *command;
+			MemoryContext oldcontext;
+			shm_mq *mq;
+			Size segsize;
+			BackgroundWorkerHandle *handle;
+			BgwHandleStatus status;
+
+			/* break in the previous case has not been reached
+			 * checking just for extra precaution
+			 */
+			Assert(UseBackgroundWorkers);
+			#if PG_VERSION_NUM < 100000
+				Assert(CurrentResourceOwner == NULL);
+				CurrentResourceOwner = ResourceOwnerCreate(NULL, "pg_cron_worker");
+			#endif
+
+			#define QUEUE_SIZE ((Size) 65536)
+
+			/*
+			 * Create the shared memory that we will pass to the background
+			 * worker process.  We use DSM_CREATE_NULL_IF_MAXSEGMENTS so that we
+			 * do not ERROR here.  This way, we can mark the job as failed and
+			 * keep the launcher process running normally.
+			 */
+			shm_toc_initialize_estimator(&e);
+			shm_toc_estimate_chunk(&e, strlen(cronJob->database) + 1);
+			shm_toc_estimate_chunk(&e, strlen(cronJob->userName) + 1);
+			shm_toc_estimate_chunk(&e, strlen(cronJob->command) + 1);
+			shm_toc_estimate_chunk(&e, QUEUE_SIZE);
+			shm_toc_estimate_keys(&e, PG_CRON_NKEYS);
+			segsize = shm_toc_estimate(&e);
+
+			task->seg = dsm_create(segsize, DSM_CREATE_NULL_IF_MAXSEGMENTS);
+			if (task->seg == NULL)
+			{
 				task->state = CRON_TASK_ERROR;
+				task->errorMessage = "unable to create a DSM segment; more "
+								"details may be available in the server log";
+
 				break;
 			}
 
-			startDeadline = TimestampTzPlusMilliseconds(currentTime,
-														CronTaskStartTimeout);
+			toc = shm_toc_create(PG_CRON_MAGIC, dsm_segment_address(task->seg), segsize);
 
-			task->startDeadline = startDeadline;
-			task->connection = connection;
-			task->pollingStatus = PGRES_POLLING_WRITING;
-			task->state = CRON_TASK_CONNECTING;
+			database = shm_toc_allocate(toc, strlen(cronJob->database) + 1);
+			strcpy(database, cronJob->database);
+			shm_toc_insert(toc, PG_CRON_KEY_DATABASE, database);
 
+			username = shm_toc_allocate(toc, strlen(cronJob->userName) + 1);
+			strcpy(username, cronJob->userName);
+			shm_toc_insert(toc, PG_CRON_KEY_USERNAME, username);
+
+			command = shm_toc_allocate(toc, strlen(cronJob->command) + 1);
+			strcpy(command, cronJob->command);
+			shm_toc_insert(toc, PG_CRON_KEY_COMMAND, command);
+
+			mq = shm_mq_create(shm_toc_allocate(toc, QUEUE_SIZE), QUEUE_SIZE);
+			shm_toc_insert(toc, PG_CRON_KEY_QUEUE, mq);
+			shm_mq_set_receiver(mq, MyProc);
+
+			/*
+			 * Attach the queue before launching a worker, so that we'll automatically
+			 * detach the queue if we error out.  (Otherwise, the worker might sit
+			 * there trying to write the queue long after we've gone away.)
+			 */
+			oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+			MemoryContextSwitchTo(oldcontext);
+
+			/*
+			 * Prepare the background worker.
+			 *
+			 */
+			memset(&worker, 0, sizeof(BackgroundWorker));
+			worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+			worker.bgw_start_time = BgWorkerStart_ConsistentState;
+			worker.bgw_restart_time = BGW_NEVER_RESTART;
+			sprintf(worker.bgw_library_name, "pg_cron");
+			sprintf(worker.bgw_function_name, "CronBackgroundWorker");
+#if (PG_VERSION_NUM >= 110000)
+			snprintf(worker.bgw_type, BGW_MAXLEN, "pg_cron");
+#endif
+			snprintf(worker.bgw_name, BGW_MAXLEN, "pg_cron worker");
+			worker.bgw_main_arg = UInt32GetDatum(dsm_segment_handle(task->seg));
+			worker.bgw_notify_pid = MyProcPid;
+
+			/*
+			 * Start the worker process.
+			 */
+			if (CronLogStatement)
+			{
+				ereport(LOG, (errmsg("cron job " INT64_FORMAT " starting: %s",
+										 jobId, command)));
+			}
+			if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+			{
+				dsm_detach(task->seg);
+				task->seg = NULL;
+				task->state = CRON_TASK_ERROR;
+				task->errorMessage = "could not start background process; more "
+									 "details may be available in the server log";
+				break;
+			}
+
+			task->handle = *handle;
+			status = WaitForBackgroundWorkerStartup(&task->handle, &pid);
+			if (status != BGWH_STARTED && status != BGWH_STOPPED)
+			{
+				dsm_detach(task->seg);
+				task->seg = NULL;
+				task->state = CRON_TASK_ERROR;
+				task->errorMessage = "could not start background process; more "
+									 "details may be available in the server log";
+				break;
+			}
+
+			task->state = CRON_TASK_BGW_RUNNING;
 			break;
 		}
 
@@ -979,23 +1232,15 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 		{
 			PostgresPollingStatusType pollingStatus = 0;
 
+			Assert(!UseBackgroundWorkers);
+
 			/* check if job has been removed */
-			if (!task->isActive)
-			{
-				task->errorMessage = "job cancelled";
-				task->pollingStatus = 0;
-				task->state = CRON_TASK_ERROR;
+			if (jobCanceled(task))
 				break;
-			}
 
 			/* check if timeout has been reached */
-			if (TimestampDifferenceExceeds(task->startDeadline, currentTime, 0))
-			{
-				task->errorMessage = "connection timeout";
-				task->pollingStatus = 0;
-				task->state = CRON_TASK_ERROR;
+			if (jobStartupTimeout(task, currentTime))
 				break;
-			}
 
 			/* check if connection is still alive */
 			connectionStatus = PQstatus(connection);
@@ -1048,23 +1293,15 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			char *command = cronJob->command;
 			int sendResult = 0;
 
+			Assert(!UseBackgroundWorkers);
+
 			/* check if job has been removed */
-			if (!task->isActive)
-			{
-				task->errorMessage = "job cancelled";
-				task->pollingStatus = 0;
-				task->state = CRON_TASK_ERROR;
+			if (jobCanceled(task))
 				break;
-			}
 
 			/* check if timeout has been reached */
-			if (TimestampDifferenceExceeds(task->startDeadline, currentTime, 0))
-			{
-				task->errorMessage = "connection timeout";
-				task->pollingStatus = 0;
-				task->state = CRON_TASK_ERROR;
+			if (jobStartupTimeout(task, currentTime))
 				break;
-			}
 
 			/* check if socket is ready to send */
 			if (!task->isSocketReady)
@@ -1104,15 +1341,11 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 		{
 			int connectionBusy = 0;
 			PGresult *result = NULL;
+			Assert(!UseBackgroundWorkers);
 
 			/* check if job has been removed */
-			if (!task->isActive)
-			{
-				task->errorMessage = "job cancelled";
-				task->pollingStatus = 0;
-				task->state = CRON_TASK_ERROR;
+			if (jobCanceled(task))
 				break;
-			}
 
 			/* check if connection is still alive */
 			connectionStatus = PQstatus(connection);
@@ -1141,75 +1374,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 
 			while ((result = PQgetResult(connection)) != NULL)
 			{
-				ExecStatusType executionStatus = PQresultStatus(result);
-
-				switch (executionStatus)
-				{
-					case PGRES_COMMAND_OK:
-					{
-						if (CronLogStatement)
-						{
-							char *cmdStatus = PQcmdStatus(result);
-							char *cmdTuples = PQcmdTuples(result);
-
-							ereport(LOG, (errmsg("cron job " INT64_FORMAT " completed: %s %s",
-												 jobId, cmdStatus, cmdTuples)));
-						}
-
-						break;
-					}
-
-					case PGRES_BAD_RESPONSE:
-					case PGRES_FATAL_ERROR:
-					{
-						task->errorMessage = strdup(PQresultErrorMessage(result));
-						task->freeErrorMessage = true;
-						task->pollingStatus = 0;
-						task->state = CRON_TASK_ERROR;
-
-						PQclear(result);
-
-						return;
-					}
-
-					case PGRES_COPY_IN:
-					case PGRES_COPY_OUT:
-					case PGRES_COPY_BOTH:
-					{
-						/* cannot handle COPY input/output */
-						task->errorMessage = "COPY not supported";
-						task->pollingStatus = 0;
-						task->state = CRON_TASK_ERROR;
-
-						PQclear(result);
-
-						return;
-					}
-
-					case PGRES_TUPLES_OK:
-					case PGRES_EMPTY_QUERY:
-					case PGRES_SINGLE_TUPLE:
-					case PGRES_NONFATAL_ERROR:
-					default:
-					{
-						if (CronLogStatement)
-						{
-							int tupleCount = PQntuples(result);
-							char *rowString = ngettext("row", "rows",
-													   tupleCount);
-
-							ereport(LOG, (errmsg("cron job " INT64_FORMAT " completed: "
-												 "%d %s",
-												 jobId, tupleCount,
-												 rowString)));
-						}
-
-						break;
-					}
-
-				}
-
-				PQclear(result);
+				GetTaskFeedback(NULL, result, task);
 			}
 
 			PQfinish(connection);
@@ -1217,8 +1382,47 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			task->connection = NULL;
 			task->pollingStatus = 0;
 			task->isSocketReady = false;
-			task->state = CRON_TASK_DONE;
 
+			task->state = CRON_TASK_DONE;
+			RunningTaskCount--;
+
+			break;
+		}
+
+		case CRON_TASK_BGW_RUNNING:
+		{
+			pid_t pid;
+			shm_mq_handle *responseq;
+			shm_mq *mq;
+			shm_toc *toc;
+
+			Assert(UseBackgroundWorkers);
+			/* check if job has been removed */
+			if (jobCanceled(task))
+			{
+				TerminateBackgroundWorker(&task->handle);
+				WaitForBackgroundWorkerShutdown(&task->handle);
+				dsm_unpin_mapping(task->seg);
+				dsm_detach(task->seg);
+				task->seg = NULL;
+
+				break;
+			}
+
+			/* still waiting for job to complete */
+			if (GetBackgroundWorkerPid(&task->handle, &pid) != BGWH_STOPPED)
+				break;
+
+			toc = shm_toc_attach(PG_CRON_MAGIC, dsm_segment_address(task->seg));
+			#if PG_VERSION_NUM < 100000
+				mq = shm_toc_lookup(toc, PG_CRON_KEY_QUEUE);
+			#else
+				mq = shm_toc_lookup(toc, PG_CRON_KEY_QUEUE, false);
+			#endif
+			responseq = shm_mq_attach(mq, task->seg, NULL);
+			GetTaskFeedback(responseq, NULL, task);
+
+			task->state = CRON_TASK_DONE;
 			RunningTaskCount--;
 
 			break;
@@ -1268,4 +1472,460 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 		}
 
 	}
+}
+
+static void
+GetTaskFeedback(shm_mq_handle *responseq, PGresult *result, CronTask *task)
+{
+
+	if (responseq) {
+		Size            nbytes;
+		void       *data;
+		char            msgtype;
+		StringInfoData  msg;
+
+		/*
+		 * Message-parsing routines operate on a null-terminated StringInfo,
+		 * so we must construct one.
+		 */
+		shm_mq_receive(responseq, &nbytes, &data, false);
+		initStringInfo(&msg);
+		resetStringInfo(&msg);
+		enlargeStringInfo(&msg, nbytes);
+		msg.len = nbytes;
+		memcpy(msg.data, data, nbytes);
+		msg.data[nbytes] = '\0';
+		msgtype = pq_getmsgbyte(&msg);
+		switch (msgtype)
+		{
+			case 'E':
+				{
+					ErrorData	edata;
+					pq_parse_errornotice(&msg, &edata);
+					ereport(LOG, (errmsg("cron job " INT64_FORMAT " ERROR: %s",
+									 task->jobId, edata.message)));
+					break;
+				}
+			case 'N':
+				{
+					ErrorData	edata;
+					pq_parse_errornotice(&msg, &edata);
+					ereport(LOG, (errmsg("cron job " INT64_FORMAT " NOTICE: %s",
+									 task->jobId, edata.message)));
+					break;
+				}
+			case 'T':
+					break;
+			case 'C':
+				{
+					if (CronLogStatement)
+					{
+						const char  *tag = pq_getmsgstring(&msg);
+						char *nonconst_tag;
+						char *cmdTuples;
+
+						nonconst_tag = strdup(tag);
+						cmdTuples = pg_cron_cmdTuples(nonconst_tag);
+
+						ereport(LOG, (errmsg("cron job " INT64_FORMAT " COMMAND completed: %s %s",
+											 task->jobId, nonconst_tag, cmdTuples)));
+						free(nonconst_tag);
+					}
+					break;
+				}
+			case 'A':
+			case 'D':
+			case 'G':
+			case 'H':
+			case 'W':
+			case 'Z':
+					break;
+			default:
+					elog(WARNING, "unknown message type: %c (%zu bytes)",
+						 msg.data[0], nbytes);
+					break;
+		}
+	} else {
+
+			ExecStatusType executionStatus = PQresultStatus(result);
+			switch (executionStatus)
+			{
+				case PGRES_COMMAND_OK:
+				{
+					if (CronLogStatement)
+					{
+						char *cmdStatus = PQcmdStatus(result);
+						char *cmdTuples = PQcmdTuples(result);
+
+						ereport(LOG, (errmsg("cron job " INT64_FORMAT " COMMAND completed: %s %s",
+											 task->jobId, cmdStatus, cmdTuples)));
+					}
+
+				break;
+				}
+
+				case PGRES_BAD_RESPONSE:
+				case PGRES_FATAL_ERROR:
+				{
+					task->errorMessage = strdup(PQresultErrorMessage(result));
+					task->freeErrorMessage = true;
+					task->pollingStatus = 0;
+					task->state = CRON_TASK_ERROR;
+
+					PQclear(result);
+
+					return;
+				}
+
+				case PGRES_COPY_IN:
+				case PGRES_COPY_OUT:
+				case PGRES_COPY_BOTH:
+				{
+					/* cannot handle COPY input/output */
+					task->errorMessage = "COPY not supported";
+					task->pollingStatus = 0;
+					task->state = CRON_TASK_ERROR;
+
+					PQclear(result);
+
+					return;
+				}
+
+				case PGRES_TUPLES_OK:
+				case PGRES_EMPTY_QUERY:
+				case PGRES_SINGLE_TUPLE:
+				case PGRES_NONFATAL_ERROR:
+				default:
+				{
+					if (CronLogStatement)
+					{
+						int tupleCount = PQntuples(result);
+						char *rowString = ngettext("row", "rows",
+											   tupleCount);
+
+						ereport(LOG, (errmsg("cron job " INT64_FORMAT " completed: "
+											 "%d %s",
+											 task->jobId, tupleCount,
+											 rowString)));
+					}
+
+					break;
+				}
+
+			}
+
+			PQclear(result);
+	}
+}
+
+/*
+ * Background worker logic.
+ */
+void
+CronBackgroundWorker(Datum main_arg)
+{
+	dsm_segment *seg;
+	shm_toc *toc;
+	char *database;
+	char *username;
+	char *command;
+	shm_mq *mq;
+	shm_mq_handle *responseq;
+
+	pqsignal(SIGTERM, pg_cron_background_worker_sigterm);
+	BackgroundWorkerUnblockSignals();
+
+	/* Set up a memory context and resource owner. */
+	Assert(CurrentResourceOwner == NULL);
+	CurrentResourceOwner = ResourceOwnerCreate(NULL, "pg_cron");
+	CurrentMemoryContext = AllocSetContextCreate(TopMemoryContext,
+												 "pg_cron worker",
+												 ALLOCSET_DEFAULT_MINSIZE,
+												 ALLOCSET_DEFAULT_INITSIZE,
+												 ALLOCSET_DEFAULT_MAXSIZE);
+
+	/* Set up a dynamic shared memory segment. */
+	seg = dsm_attach(DatumGetInt32(main_arg));
+	if (seg == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("unable to map dynamic shared memory segment")));
+	toc = shm_toc_attach(PG_CRON_MAGIC, dsm_segment_address(seg));
+	if (toc == NULL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+			   errmsg("bad magic number in dynamic shared memory segment")));
+
+	#if PG_VERSION_NUM < 100000
+		database = shm_toc_lookup(toc, PG_CRON_KEY_DATABASE);
+		username = shm_toc_lookup(toc, PG_CRON_KEY_USERNAME);
+		command = shm_toc_lookup(toc, PG_CRON_KEY_COMMAND);
+		mq = shm_toc_lookup(toc, PG_CRON_KEY_QUEUE);
+	#else
+		database = shm_toc_lookup(toc, PG_CRON_KEY_DATABASE, false);
+		username = shm_toc_lookup(toc, PG_CRON_KEY_USERNAME, false);
+		command = shm_toc_lookup(toc, PG_CRON_KEY_COMMAND, false);
+		mq = shm_toc_lookup(toc, PG_CRON_KEY_QUEUE, false);
+	#endif
+
+	shm_mq_set_sender(mq, MyProc);
+	responseq = shm_mq_attach(mq, seg, NULL);
+	pq_redirect_to_shm_mq(seg, responseq);
+
+#if (PG_VERSION_NUM < 110000)
+	BackgroundWorkerInitializeConnection(database, username);
+#else
+	BackgroundWorkerInitializeConnection(database, username, 0);
+#endif
+
+	/* Prepare to execute the query. */
+	SetCurrentStatementStartTimestamp();
+	debug_query_string = command;
+	pgstat_report_activity(STATE_RUNNING, command);
+	StartTransactionCommand();
+	if (StatementTimeout > 0)
+		enable_timeout_after(STATEMENT_TIMEOUT, StatementTimeout);
+	else
+		disable_timeout(STATEMENT_TIMEOUT, false);
+
+	/* Execute the query. */
+	ExecuteSqlString(command);
+
+	/* Post-execution cleanup. */
+	disable_timeout(STATEMENT_TIMEOUT, false);
+	CommitTransactionCommand();
+	ProcessCompletedNotifies();
+	pgstat_report_activity(STATE_IDLE, command);
+	pgstat_report_stat(true);
+
+	/* Signal that we are done. */
+	ReadyForQuery(DestRemote);
+
+	dsm_detach(seg);
+	proc_exit(0);
+}
+
+/*
+ * Execute given SQL string without SPI or a libpq session.
+ */
+static void
+ExecuteSqlString(const char *sql)
+{
+	List *raw_parsetree_list;
+	ListCell *lc1;
+	bool isTopLevel;
+	int commands_remaining;
+	MemoryContext parsecontext;
+	MemoryContext oldcontext;
+
+	/*
+	 * Parse the SQL string into a list of raw parse trees.
+	 *
+	 * Because we allow statements that perform internal transaction control,
+	 * we can't do this in TopTransactionContext; the parse trees might get
+	 * blown away before we're done executing them.
+	 */
+	parsecontext = AllocSetContextCreate(TopMemoryContext,
+										 "pg_cron parse/plan",
+										 ALLOCSET_DEFAULT_MINSIZE,
+										 ALLOCSET_DEFAULT_INITSIZE,
+										 ALLOCSET_DEFAULT_MAXSIZE);
+	oldcontext = MemoryContextSwitchTo(parsecontext);
+	raw_parsetree_list = pg_parse_query(sql);
+	commands_remaining = list_length(raw_parsetree_list);
+	isTopLevel = commands_remaining == 1;
+	MemoryContextSwitchTo(oldcontext);
+
+	/*
+	 * Do parse analysis, rule rewrite, planning, and execution for each raw
+	 * parsetree.  We must fully execute each query before beginning parse
+	 * analysis on the next one, since there may be interdependencies.
+	 */
+	foreach(lc1, raw_parsetree_list)
+	{
+		#if PG_VERSION_NUM < 100000
+			Node *parsetree = (Node *) lfirst(lc1);
+		#else
+			RawStmt *parsetree = (RawStmt *)  lfirst(lc1);
+		#endif
+
+		#if PG_VERSION_NUM < 130000
+			const char *commandTag;
+			char completionTag[COMPLETION_TAG_BUFSIZE];
+		#else
+			CommandTag commandTag;
+			QueryCompletion qc;
+		#endif
+
+		List *querytree_list;
+		List *plantree_list;
+		bool snapshot_set = false;
+		Portal portal;
+		DestReceiver *receiver;
+		int16 format = 1;
+
+		/*
+		 * We don't allow transaction-control commands like COMMIT and ABORT
+		 * here.  The entire SQL statement is executed as a single transaction
+		 * which commits if no errors are encountered.
+		 */
+		if (IsA(parsetree, TransactionStmt))
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					 errmsg("transaction control statements are not allowed in pg_cron")));
+
+		/*
+		 * Get the command name for use in status display (it also becomes the
+		 * default completion tag, down inside PortalRun).  Set ps_status and
+		 * do any special start-of-SQL-command processing needed by the
+		 * destination.
+		 */
+		#if PG_VERSION_NUM < 100000
+			commandTag = CreateCommandTag(parsetree);
+		#else
+			commandTag = CreateCommandTag(parsetree->stmt);
+		#endif
+
+
+		#if PG_VERSION_NUM < 130000
+			set_ps_display(commandTag, false);
+		#else
+			set_ps_display(GetCommandTagName(commandTag), false);
+		#endif
+
+		BeginCommand(commandTag, DestNone);
+
+		/* Set up a snapshot if parse analysis/planning will need one. */
+		if (analyze_requires_snapshot(parsetree))
+		{
+			PushActiveSnapshot(GetTransactionSnapshot());
+			snapshot_set = true;
+		}
+
+		/*
+		 * OK to analyze, rewrite, and plan this query.
+		 *
+		 * As with parsing, we need to make sure this data outlives the
+		 * transaction, because of the possibility that the statement might
+		 * perform internal transaction control.
+		 */
+		oldcontext = MemoryContextSwitchTo(parsecontext);
+		#if PG_VERSION_NUM >= 100000
+			querytree_list = pg_analyze_and_rewrite(parsetree, sql, NULL, 0,NULL);
+		#else
+			querytree_list = pg_analyze_and_rewrite(parsetree, sql, NULL, 0);
+		#endif
+
+		plantree_list = pg_plan_queries(querytree_list, 0, NULL);
+
+		/* Done with the snapshot used for parsing/planning */
+		if (snapshot_set)
+			PopActiveSnapshot();
+
+		/* If we got a cancel signal in analysis or planning, quit */
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * Execute the query using the unnamed portal.
+		 */
+		portal = CreatePortal("", true, true);
+		/* Don't display the portal in pg_cursors */
+		portal->visible = false;
+		PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
+		PortalStart(portal, NULL, 0, InvalidSnapshot);
+		PortalSetResultFormat(portal, 1, &format);		/* binary format */
+
+		--commands_remaining;
+		receiver = CreateDestReceiver(DestNone);
+
+		/*
+		 * Only once the portal and destreceiver have been established can
+		 * we return to the transaction context.  All that stuff needs to
+		 * survive an internal commit inside PortalRun!
+		 */
+		MemoryContextSwitchTo(oldcontext);
+
+		/* Here's where we actually execute the command. */
+		#if PG_VERSION_NUM < 100000
+			(void) PortalRun(portal, FETCH_ALL, isTopLevel, receiver, receiver, completionTag);
+		#elif PG_VERSION_NUM < 130000
+			(void) PortalRun(portal, FETCH_ALL, isTopLevel,true, receiver, receiver, completionTag);
+		#else
+			(void) PortalRun(portal, FETCH_ALL, isTopLevel, true, receiver, receiver, &qc);
+		#endif
+
+		/* Clean up the receiver. */
+		(*receiver->rDestroy) (receiver);
+
+		/*
+		 * Send a CommandComplete message even if we suppressed the query
+		 * results.  The user backend will report these in the absence of
+		 * any true query results.
+		 */
+		#if PG_VERSION_NUM < 130000
+			EndCommand(completionTag, DestRemote);
+		#else
+			EndCommand(&qc, DestRemote, false);
+		#endif
+
+		/* Clean up the portal. */
+		PortalDrop(portal, false);
+	}
+
+	/* Be sure to advance the command counter after the last script command */
+	CommandCounterIncrement();
+}
+
+/*
+ * If a task is not marked as active, set an appropriate error state on the task
+ * and return true. Note that this should only be called after a task has
+ * already been launched.
+ */
+static bool
+jobCanceled(CronTask *task)
+{
+    Assert(task->state == CRON_TASK_CONNECTING || \
+            task->state == CRON_TASK_SENDING || \
+            task->state == CRON_TASK_BGW_RUNNING || \
+            task->state == CRON_TASK_RUNNING);
+
+    if (task->isActive)
+        return false;
+    else
+    {
+        /* Use the American spelling for consistency with PG code. */
+        task->errorMessage = "job canceled";
+        task->state = CRON_TASK_ERROR;
+
+        /*
+         * Technically, pollingStatus is only used by when UseBackgroundWorkers
+         * is false, but no damage in setting it in both cases.
+         */
+        task->pollingStatus = 0;
+        return true;
+    }
+}
+
+/*
+ * If a task has hit it's startup deadline, set an appropriate error state on
+ * the task and return true. Note that this should only be called after a task
+ * has already been launched. It's not used when UseBackgroundWorkers is true
+ * (if that were to change the error message wouldn't make sense).
+ */
+static bool
+jobStartupTimeout(CronTask *task, TimestampTz currentTime)
+{
+    Assert(!UseBackgroundWorkers);
+    Assert(task->state == CRON_TASK_CONNECTING || \
+            task->state == CRON_TASK_SENDING);
+
+    if (TimestampDifferenceExceeds(task->startDeadline, currentTime, 0))
+    {
+        task->errorMessage = "connection timeout";
+        task->pollingStatus = 0;
+        task->state = CRON_TASK_ERROR;
+        return true;
+    }
+    else
+        return false;
 }

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -113,7 +113,7 @@ void _PG_fini(void);
 static void pg_cron_sigterm(SIGNAL_ARGS);
 static void pg_cron_sighup(SIGNAL_ARGS);
 static void pg_cron_background_worker_sigterm(SIGNAL_ARGS);
-void PgCronWorkerMain(Datum arg);
+void PgCronLauncherMain(Datum arg);
 void CronBackgroundWorker(Datum arg);
 
 static void StartAllPendingRuns(List *taskList, TimestampTz currentTime);
@@ -242,15 +242,15 @@ _PG_init(void)
 	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
 	worker.bgw_restart_time = 1;
 #if (PG_VERSION_NUM < 100000)
-	worker.bgw_main = PgCronWorkerMain;
+	worker.bgw_main = PgCronLauncherMain;
 #endif
 	worker.bgw_main_arg = Int32GetDatum(0);
 	worker.bgw_notify_pid = 0;
 	sprintf(worker.bgw_library_name, "pg_cron");
-	sprintf(worker.bgw_function_name, "PgCronWorkerMain");
-	snprintf(worker.bgw_name, BGW_MAXLEN, "pg_cron scheduler");
+	sprintf(worker.bgw_function_name, "PgCronLauncherMain");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "pg_cron launcher");
 #if (PG_VERSION_NUM >= 110000)
-	snprintf(worker.bgw_type, BGW_MAXLEN, "pg_cron scheduler");
+	snprintf(worker.bgw_type, BGW_MAXLEN, "pg_cron launcher");
 #endif
 
 	RegisterBackgroundWorker(&worker);
@@ -371,11 +371,11 @@ pg_cron_background_worker_sigterm(SIGNAL_ARGS)
 
 
 /*
- * PgCronWorkerMain is the main entry-point for the background worker
+ * PgCronLauncherMain is the main entry-point for the background worker
  * that performs tasks.
  */
 void
-PgCronWorkerMain(Datum arg)
+PgCronLauncherMain(Datum arg)
 {
 	MemoryContext CronLoopContext = NULL;
 	struct rlimit limit;


### PR DESCRIPTION
This PR is mainly made of 4 commits:

1. background worker support
2. audit table support
3. job and task wording
4. renamed bgworker scheduler to launcher

## Let's explain each commit

### background worker support

This commit is adding support for using background workers instead of libpq sessions to execute the jobs.
This behavior is guarded behind a GUC and disabled by default so that it does not impact backward compatibility.
The background workers use a similar technique to the `pg_background` extension to run commands, and things like cron.host, nodename, and nodeport have no effect in this mode.

### audit table support

This commit is adding support for an audit table.
It works for either libpq or background-worker mode.

content looks like:

```
postgres=# select * from cron.job_run_details;
 jobid | runid | job_pid | database | username |                  command                   |  status   |         return_message         |          start_time           |           end_time
-------+-------+---------+----------+----------+--------------------------------------------+-----------+--------------------------------+-------------------------------+-------------------------------
     6 |     2 |   15073 | postgres | bdt      | insert into bdtcron values(1)              | succeeded | INSERT 0 1                     | 2020-08-18 12:43:01.004976+00 | 2020-08-18 12:43:01.009695+00
     2 |     3 |   15074 | postgres | bdt      | update bdtcron set a = a -1                | succeeded | UPDATE 0                       | 2020-08-18 12:43:01.005747+00 | 2020-08-18 12:43:01.010155+00
     4 |     4 |   15075 | postgres | bdt      | create table tutu as select * from bdtcron | succeeded | SELECT 1                       | 2020-08-18 12:43:01.006427+00 | 2020-08-18 12:43:01.011015+00
     5 |     5 |   15076 | postgres | bdt      | select * from bdtcron                      | succeeded | SELECT 1                       | 2020-08-18 12:43:01.00724+00  | 2020-08-18 12:43:01.011435+00
     1 |     6 |   15077 | postgres | bdt      | delete from bdtcron                        | succeeded | DELETE 1                       | 2020-08-18 12:43:01.008254+00 | 2020-08-18 12:43:01.011857+00
     3 |     7 |   15078 | postgres | bdt      | vacuum bdtcron                             | succeeded | VACUUM                         | 2020-08-18 12:43:01.00887+00  | 2020-08-18 12:43:01.022352+00
     6 |     8 |   15080 | postgres | bdt      | insert into bdtcron values(1)              | succeeded | INSERT 0 1                     | 2020-08-18 12:44:01.004167+00 | 2020-08-18 12:44:01.009513+00
     2 |     9 |   15081 | postgres | bdt      | update bdtcron set a = a -1                | succeeded | UPDATE 0                       | 2020-08-18 12:44:01.004883+00 | 2020-08-18 12:44:01.010053+00
     4 |    10 |   15082 | postgres | bdt      | create table tutu as select * from bdtcron | failed    | relation "tutu" already exists | 2020-08-18 12:44:01.005524+00 | 2020-08-18 12:44:01.010601+00
     5 |    11 |   15083 | postgres | bdt      | select * from bdtcron                      | succeeded | SELECT 1                       | 2020-08-18 12:44:01.006221+00 | 2020-08-18 12:44:01.011112+00
     1 |    12 |   15084 | postgres | bdt      | delete from bdtcron                        | succeeded | DELETE 1                       | 2020-08-18 12:44:01.00723+00  | 2020-08-18 12:44:01.011554+00
```

### job and task wording

This commit is adding some wording about job and task.

### renamed bgworker scheduler to launcher

This commit is renaming the current background worker from "scheduler" to "launcher" (to go with autovac nomenclature) to avoid confusion with the new workers.