### PR TITLE
docs: fix simple typo, implmented -> implemented

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -381,7 +381,7 @@ get_range(bits, low, high, names, ch, file)
 	/* range. set all elements from num1 to num2, stepping
 	 * by num3.  (the step is a downward-compatible extension
 	 * proposed conceptually by bob@acornrc, syntactically
-	 * designed then implmented by paul vixie).
+	 * designed then implemented by paul vixie).
 	 */
 	for (i = num1;  i <= num2;  i += num3)
 		if (EOF == set_element(bits, low, high, i))


### PR DESCRIPTION
There is a small typo in src/entry.c.

Should read `implemented` rather than `implmented`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md