### PR TITLE
add alter_job() and update schedule() with more options

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -5,11 +5,11 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.0
 (1 row)
 
-ALTER EXTENSION pg_cron UPDATE TO '1.3';
+ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  extversion 
 ------------
- 1.3
+ 1.4
 (1 row)
 
 -- Vacuum every day at 10:00am (GMT)
@@ -93,4 +93,102 @@ SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
      2 |         | @restart | ALTER EXTENSION pg_cron UPDATE
 (1 row)
 
+-- Testing version >= 1.4 new APIs
+-- First as superuser
+-- Update a job without one job attribute to change
+SELECT cron.alter_job(2);
+ERROR:  no updates specified
+HINT:  You must specify at least one job attribute to change when calling alter_job
+-- Update to a non existing database
+select cron.alter_job(job_id:=2,database:='hopedoesnotexist');
+ERROR:  database "hopedoesnotexist" does not exist
+-- Create a database that does not allow connection
+create database pgcron_dbno;
+revoke connect on database pgcron_dbno from public;
+-- create a test user
+create user pgcron_cront with password 'pwd';
+GRANT USAGE ON SCHEMA cron TO pgcron_cront;
+-- Schedule a job for this user on the database that does not accept connections
+SELECT cron.schedule(job_name:='can not connect', schedule:='0 11 * * *', command:='VACUUM',database:='pgcron_dbno',username:='pgcron_cront');
+ERROR:  User pgcron_cront does not have CONNECT privilege on pgcron_dbno
+-- Create a database that does allow connections
+create database pgcron_dbyes;
+-- Schedule a job on the database that does accept connections for a non existing user
+SELECT cron.schedule(job_name:='user does not exist', schedule:='0 11 * * *', command:='VACUUM',database:='pgcron_dbyes',username:='pgcron_useraqwxszedc');
+ERROR:  role "pgcron_useraqwxszedc" does not exist
+-- Alter an existing job on a database that does not accept connections
+SELECT cron.alter_job(job_id:=2,database:='pgcron_dbno',username:='pgcron_cront');
+ERROR:  User pgcron_cront does not have CONNECT privilege on pgcron_dbno
+-- Second as non superuser
+SET SESSION AUTHORIZATION pgcron_cront;
+-- Create a job
+SELECT cron.schedule('My vacuum', '0 11 * * *', 'VACUUM');
+ schedule 
+----------
+        6
+(1 row)
+
+-- Create a job for another user
+SELECT cron.schedule(job_name:='his vacuum', schedule:='0 11 * * *', command:='VACUUM',username:='anotheruser');
+ERROR:  must be superuser to create a job for another role
+-- Change the username of an existing job that the user own
+select cron.alter_job(job_id:=6,username:='anotheruser');
+ERROR:  must be superuser to alter username
+-- Update a job that the user does not own
+select cron.alter_job(job_id:=2,database:='pgcron_dbyes');
+ERROR:  Job 2 does not exist or you don't own it
+-- change the database for a job that the user own and can connect to
+select cron.alter_job(job_id:=6,database:='pgcron_dbyes');
+ alter_job 
+-----------
+ 
+(1 row)
+
+SELECT database FROM cron.job;
+   database   
+--------------
+ pgcron_dbyes
+(1 row)
+
+-- change the database for a job that the user own but can not connect to
+select cron.alter_job(job_id:=6,database:='pgcron_dbno');
+ERROR:  User pgcron_cront does not have CONNECT privilege on pgcron_dbno
+SELECT database FROM cron.job;
+   database   
+--------------
+ pgcron_dbyes
+(1 row)
+
+-- back to superuser
+RESET SESSION AUTHORIZATION;
+-- Change the username of an existing job
+select cron.alter_job(job_id:=2,username:='pgcron_cront');
+ alter_job 
+-----------
+ 
+(1 row)
+
+SELECT username FROM cron.job where jobid=2;
+   username   
+--------------
+ pgcron_cront
+(1 row)
+
+-- Create a job for another user
+SELECT cron.schedule(job_name:='his vacuum', schedule:='0 11 * * *', command:='VACUUM',username:='pgcron_cront');
+ schedule 
+----------
+        7
+(1 row)
+
+SELECT username FROM cron.job where jobid=7;
+   username   
+--------------
+ pgcron_cront
+(1 row)
+
+-- cleaning
 DROP EXTENSION pg_cron;
+drop user pgcron_cront;
+drop database pgcron_dbno;
+drop database pgcron_dbyes;

--- a/pg_cron--1.3--1.4.sql
+++ b/pg_cron--1.3--1.4.sql
@@ -1,0 +1,27 @@
+/* pg_cron--1.3--1.4.sql */
+
+CREATE FUNCTION cron.alter_job(job_id bigint,
+								schedule text default null,
+								command text default null,
+								database text default null,
+								username text default null,
+								active boolean default null)
+RETURNS void
+LANGUAGE C
+AS 'MODULE_PATHNAME', $$cron_alter_job$$;
+
+COMMENT ON FUNCTION cron.alter_job(bigint,text,text,text,text,boolean)
+IS 'Alter the job identified by job_id. Any option left as NULL will not be modified.';
+
+CREATE FUNCTION cron.schedule(job_name text,
+								schedule text,
+								command text,
+								database text default null,
+								username text default null,
+								active boolean default 'true')
+RETURNS bigint
+LANGUAGE C
+AS 'MODULE_PATHNAME', $$cron_schedule_named$$;
+
+COMMENT ON FUNCTION cron.schedule(text,text,text,text,text,boolean)
+IS 'schedule a pg_cron job';

--- a/pg_cron.control
+++ b/pg_cron.control
@@ -1,4 +1,4 @@
 comment = 'Job scheduler for PostgreSQL'
-default_version = '1.3'
+default_version = '1.4'
 module_pathname = '$libdir/pg_cron'
 relocatable = false

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION pg_cron VERSION '1.0';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
-ALTER EXTENSION pg_cron UPDATE TO '1.3';
+ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 
 -- Vacuum every day at 10:00am (GMT)
@@ -37,4 +37,71 @@ SELECT cron.unschedule('myvacuum');
 
 SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
 
+-- Testing version >= 1.4 new APIs
+-- First as superuser
+
+-- Update a job without one job attribute to change
+SELECT cron.alter_job(2);
+
+-- Update to a non existing database
+select cron.alter_job(job_id:=2,database:='hopedoesnotexist');
+
+-- Create a database that does not allow connection
+create database pgcron_dbno;
+revoke connect on database pgcron_dbno from public;
+
+-- create a test user
+create user pgcron_cront with password 'pwd';
+GRANT USAGE ON SCHEMA cron TO pgcron_cront;
+
+-- Schedule a job for this user on the database that does not accept connections
+SELECT cron.schedule(job_name:='can not connect', schedule:='0 11 * * *', command:='VACUUM',database:='pgcron_dbno',username:='pgcron_cront');
+
+-- Create a database that does allow connections
+create database pgcron_dbyes;
+
+-- Schedule a job on the database that does accept connections for a non existing user
+SELECT cron.schedule(job_name:='user does not exist', schedule:='0 11 * * *', command:='VACUUM',database:='pgcron_dbyes',username:='pgcron_useraqwxszedc');
+
+-- Alter an existing job on a database that does not accept connections
+SELECT cron.alter_job(job_id:=2,database:='pgcron_dbno',username:='pgcron_cront');
+
+-- Second as non superuser
+SET SESSION AUTHORIZATION pgcron_cront;
+
+-- Create a job
+SELECT cron.schedule('My vacuum', '0 11 * * *', 'VACUUM');
+
+-- Create a job for another user
+SELECT cron.schedule(job_name:='his vacuum', schedule:='0 11 * * *', command:='VACUUM',username:='anotheruser');
+
+-- Change the username of an existing job that the user own
+select cron.alter_job(job_id:=6,username:='anotheruser');
+
+-- Update a job that the user does not own
+select cron.alter_job(job_id:=2,database:='pgcron_dbyes');
+
+-- change the database for a job that the user own and can connect to
+select cron.alter_job(job_id:=6,database:='pgcron_dbyes');
+SELECT database FROM cron.job;
+
+-- change the database for a job that the user own but can not connect to
+select cron.alter_job(job_id:=6,database:='pgcron_dbno');
+SELECT database FROM cron.job;
+
+-- back to superuser
+RESET SESSION AUTHORIZATION;
+
+-- Change the username of an existing job
+select cron.alter_job(job_id:=2,username:='pgcron_cront');
+SELECT username FROM cron.job where jobid=2;
+
+-- Create a job for another user
+SELECT cron.schedule(job_name:='his vacuum', schedule:='0 11 * * *', command:='VACUUM',username:='pgcron_cront');
+SELECT username FROM cron.job where jobid=7;
+
+-- cleaning
 DROP EXTENSION pg_cron;
+drop user pgcron_cront;
+drop database pgcron_dbno;
+drop database pgcron_dbyes;


### PR DESCRIPTION
### Purpose

Add options to the schedule() function: can specify a database, username,...  
Create a new function: alter_job() to give the ability to alter an existing job (change database, username, schedule, command...)  

### Remarks

 * **Only superuser** can create a job with another username or alter an existing job with another username.
 * When database is specified (in schedule() or alter_job()), then a check is done to ensure that the database exists and also that the username that will be part of the job can connect to it.

### Testing

#### Setup:  create the extension as superuser, create a job, GRANT USAGE ON SCHEMA cron TO cront, and 2 databases (one of them does not accept connections)

```
postgres=> create user cront with password 'bdt';
CREATE ROLE
postgres=> create extension pg_cron;
CREATE EXTENSION
postgres=> GRANT USAGE ON SCHEMA cron TO cront;
GRANT
postgres=> create database dbyes;
CREATE DATABASE
postgres=> create database dbno;
CREATE DATABASE
postgres=> revoke connect on database dbno from public;
REVOKE
postgres=> create table crontest (a int);
CREATE TABLE
postgres=> SELECT cron.schedule('delete crontest', '* * * * *', 'delete from crontest');
 schedule
----------
        1
(1 row)

postgres=#  select * from cron.job;
 jobid | schedule  |       command        | nodename  | nodeport | database | username | active |     jobname
-------+-----------+----------------------+-----------+----------+----------+----------+--------+-----------------
     1 | * * * * * | delete from crontest | localhost |     5432 | postgres | postgres | t      | delete crontest
(1 row)
```

#### connect as cront, create a job, try to update with DML and use the alter_job function instead

```
postgres=> create table crontest2 (a int);
CREATE TABLE
postgres=> SELECT cron.schedule('delete crontest2', '* * * * *', 'delete from crontest2');
 schedule
----------
        2
(1 row)

postgres=> select * from cron.job;
 jobid | schedule  |        command        | nodename  | nodeport | database | username | active |     jobname
-------+-----------+-----------------------+-----------+----------+----------+----------+--------+------------------
     2 | * * * * * | delete from crontest2 | localhost |     5432 | postgres | cront    | t      | delete crontest2
(1 row)

postgres=> update cron.job set database = 'cronj' where jobid = 2;
ERROR:  permission denied for table job

postgres=> select cron.alter_job(2);
ERROR:  no updates specified
HINT:  You must specify at least one job attribute to change when calling alter_job

postgres=> select cron.alter_job(job_id:=2,database:='tutu');
ERROR:  database "tutu" does not exist

postgres=> select cron.alter_job(job_id:=2,database:='dbno');
ERROR:  User cront does not have CONNECT privilege on dbno

postgres=> select cron.alter_job(job_id:=2,database:='dbyes',username:='tutu');
ERROR:  must be superuser to alter username

postgres=> select cron.alter_job(job_id:=3,database:='dbyes');
ERROR:  Job 3 does not exist or you don't own it

postgres=> select cron.alter_job(job_id:=2,database:='dbyes');
 alter_job
-----------

(1 row)

postgres=> select * from cron.job;
 jobid | schedule  |        command        | nodename  | nodeport | database | username | active |     jobname
-------+-----------+-----------------------+-----------+----------+----------+----------+--------+------------------
     2 | * * * * * | delete from crontest2 | localhost |     5432 | dbyes    | cront    | t      | delete crontest2
(1 row)
```

#### connect as cront, create a job trying to specify username and/or database
```
postgres=> SELECT cron.schedule(job_name:='delete crontest2', schedule:='* * * * *', command:='delete from crontest2',username:='tutu');
ERROR:  must be superuser to create a job for another role

postgres=> SELECT cron.schedule(job_name:='delete crontest2', schedule:='* * * * *', command:='delete from crontest2',database:='tutu');
ERROR:  database "tutu" does not exist

postgres=> SELECT cron.schedule(job_name:='delete crontest2', schedule:='* * * * *', command:='delete from crontest2',database:='dbno');
ERROR:  User cront does not have CONNECT privilege on dbno

postgres=> SELECT cron.schedule(job_name:='delete crontest2', schedule:='* * * * *', command:='delete from crontest2',database:='dbyes');
 schedule
----------
        2
(1 row)

postgres=> select * from cron.job;
 jobid | schedule  |        command        | nodename  | nodeport | database | username | active |     jobname
-------+-----------+-----------------------+-----------+----------+----------+----------+--------+------------------
     2 | * * * * * | delete from crontest2 | localhost |     5432 | dbyes    | cront    | t      | delete crontest2
(1 row)
```

#### connect as superuser, verify that he can specify username
```
postgres=# select * from cron.job;
 jobid | schedule  |        command        | nodename  | nodeport | database | username | active |     jobname
-------+-----------+-----------------------+-----------+----------+----------+----------+--------+------------------
     1 | * * * * * | delete from crontest  | localhost |     5432 | postgres | postgres | t      | delete crontest
     2 | * * * * * | delete from crontest2 | localhost |     5432 | dbyes    | cront    | t      | delete crontest2
(2 rows)

postgres=# SELECT cron.schedule(job_name:='delete crontest2 with bdt2', schedule:='* * * * *', command:='delete from crontest2',username:='bdt2');
 schedule
----------
        6
(1 row)

postgres=# select * from cron.job;
 jobid | schedule  |        command        | nodename  | nodeport | database | username | active |          jobname
-------+-----------+-----------------------+-----------+----------+----------+----------+--------+----------------------------
     1 | * * * * * | delete from crontest  | localhost |     5432 | postgres | postgres | t      | delete crontest
     2 | * * * * * | delete from crontest2 | localhost |     5432 | dbyes    | cront    | t      | delete crontest2
     6 | * * * * * | delete from crontest2 | localhost |     5432 | postgres | bdt2     | t      | delete crontest2 with bdt2
(3 rows)


postgres=# select cron.alter_job(job_id:=6,username:='cront');
 alter_job
-----------

(1 row)

postgres=# select * from cron.job;
 jobid | schedule  |        command        | nodename  | nodeport | database | username | active |          jobname
-------+-----------+-----------------------+-----------+----------+----------+----------+--------+----------------------------
     1 | * * * * * | delete from crontest  | localhost |     5432 | postgres | postgres | t      | delete crontest
     2 | * * * * * | delete from crontest2 | localhost |     5432 | dbyes    | cront    | t      | delete crontest2
     6 | * * * * * | delete from crontest2 | localhost |     5432 | postgres | cront    | t      | delete crontest2 with bdt2
(3 rows)

postgres=> SELECT cron.schedule(job_name:='delete for bdt3', schedule:='* * * * *', command:='delete from crontest2',database:='dbyes', username:='bdt3');
ERROR:  role "bdt3" does not exist
```