### PR TITLE
Always reset memory context in job_metadata functions

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -505,6 +505,7 @@ NextRunId(void)
 	Datum jobIdDatum = 0;
 	int64 jobId = 0;
 	bool failOK = true;
+	MemoryContext originalContext = CurrentMemoryContext;
 
 	StartTransactionCommand();
 	PushActiveSnapshot(GetTransactionSnapshot());
@@ -513,6 +514,7 @@ NextRunId(void)
 	{
 		PopActiveSnapshot();
 		CommitTransactionCommand();
+		MemoryContextSwitchTo(originalContext);
 
 		/* if the job_run_details table is not yet created, the run ID is not used */
 		return 0;
@@ -537,6 +539,7 @@ NextRunId(void)
 
 	PopActiveSnapshot();
 	CommitTransactionCommand();
+	MemoryContextSwitchTo(originalContext);
 
 	return jobId;
 }
@@ -820,6 +823,7 @@ LoadCronJobList(void)
 	{
 		PopActiveSnapshot();
 		CommitTransactionCommand();
+		MemoryContextSwitchTo(originalContext);
 		pgstat_report_activity(STATE_IDLE, NULL);
 
 		return NIL;
@@ -854,9 +858,8 @@ LoadCronJobList(void)
 
 	PopActiveSnapshot();
 	CommitTransactionCommand();
-	pgstat_report_activity(STATE_IDLE, NULL);
-
 	MemoryContextSwitchTo(originalContext);
+	pgstat_report_activity(STATE_IDLE, NULL);
 
 	return jobList;
 }
@@ -992,6 +995,7 @@ InsertJobRunDetail(int64 runId, int64 *jobId, char *database, char *username, ch
 	const int argCount = 6;
 	Oid argTypes[6];
 	Datum argValues[6];
+	MemoryContext originalContext = CurrentMemoryContext;
 
 	SetCurrentStatementStartTimestamp();
 	StartTransactionCommand();
@@ -1001,6 +1005,7 @@ InsertJobRunDetail(int64 runId, int64 *jobId, char *database, char *username, ch
 	{
 		PopActiveSnapshot();
 		CommitTransactionCommand();
+		MemoryContextSwitchTo(originalContext);
 		return;
 	}
 
@@ -1050,6 +1055,7 @@ InsertJobRunDetail(int64 runId, int64 *jobId, char *database, char *username, ch
 	SPI_finish();
 	PopActiveSnapshot();
 	CommitTransactionCommand();
+	MemoryContextSwitchTo(originalContext);
 	pgstat_report_activity(STATE_IDLE, NULL);
 }
 
@@ -1061,6 +1067,7 @@ UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_messa
 	Oid argTypes[6];
 	Datum argValues[6];
 	int i;
+	MemoryContext originalContext = CurrentMemoryContext;
 
 	SetCurrentStatementStartTimestamp();
 	StartTransactionCommand();
@@ -1070,6 +1077,7 @@ UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_messa
 	{
 		PopActiveSnapshot();
 		CommitTransactionCommand();
+		MemoryContextSwitchTo(originalContext);
 		return;
 	}
 
@@ -1151,6 +1159,7 @@ UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_messa
 	SPI_finish();
 	PopActiveSnapshot();
 	CommitTransactionCommand();
+	MemoryContextSwitchTo(originalContext);
 	pgstat_report_activity(STATE_IDLE, NULL);
 }
 
@@ -1313,6 +1322,7 @@ void
 MarkPendingRunsAsFailed(void)
 {
 	StringInfoData querybuf;
+	MemoryContext originalContext = CurrentMemoryContext;
 
 	SetCurrentStatementStartTimestamp();
 	StartTransactionCommand();
@@ -1322,6 +1332,7 @@ MarkPendingRunsAsFailed(void)
 	{
 		PopActiveSnapshot();
 		CommitTransactionCommand();
+		MemoryContextSwitchTo(originalContext);
 		return;
 	}
 
@@ -1347,6 +1358,7 @@ MarkPendingRunsAsFailed(void)
 	SPI_finish();
 	PopActiveSnapshot();
 	CommitTransactionCommand();
+	MemoryContextSwitchTo(originalContext);
 	pgstat_report_activity(STATE_IDLE, NULL);
 }
 


### PR DESCRIPTION
Make sure to always reset the memory context after committing in metadata functions to avoid doing future allocations in the top memory context.

Fixes #128 