### PR TITLE
Add Aiven to the list of cloud providers with pg_cron support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The following table keeps track of which of the major managed Postgres services 
 
 | Service       | Supported     |
 | ------------- |:-------------:|
+| [Aiven](https://aiven.io/postgresql) | :heavy_check_mark: |
 | [Alibaba Cloud](https://www.alibabacloud.com/help/doc-detail/150355.htm) | :heavy_check_mark: |
 | [Amazon RDS](https://aws.amazon.com/rds/postgresql/)     | :heavy_check_mark:      |          |
 | [Azure](https://azure.microsoft.com/en-us/services/postgresql/) | :heavy_check_mark:  |


### PR DESCRIPTION
We are proud to have pg_cron available on Aiven too, so adding the link to the list.