### PR TITLE
Palloc for pointer array instead of struct array

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -1017,7 +1017,7 @@ PollForTasks(List *taskList)
 	int activeTaskCount = 0;
 	ListCell *taskCell = NULL;
 
-	polledTasks = (CronTask **) palloc0(taskCount * sizeof(CronTask));
+	polledTasks = (CronTask **) palloc0(taskCount * sizeof(CronTask *));
 	pollFDs = (struct pollfd *) palloc0(taskCount * sizeof(struct pollfd));
 
 	currentTime = GetCurrentTimestamp();


### PR DESCRIPTION
Hi. The code logic palloc a CronTask structure array, but assigns it to a pointer of two-dimension array. So the space is subsequently used as a pointer array whose type is `CronTask *`, instead of a structure array. There is no error thrown yet because the size of a `CronTask *` pointer is much less than a `CronTask` structure, so only the front part of the whole allocated space is used and an out-of-bound will never happen. But it is actually no need to allocate so much memory that won't be used.