### PR TITLE
Add cron.enable_superuser_jobs option to disallow superuser jobs

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -12,6 +12,7 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.4
 (1 row)
 
+SET cron.enable_superuser_jobs TO on;
 -- Vacuum every day at 10:00am (GMT)
 SELECT cron.schedule('0 10 * * *', 'VACUUM');
  schedule 
@@ -185,6 +186,27 @@ SELECT username FROM cron.job where jobid=7;
    username   
 --------------
  pgcron_cront
+(1 row)
+
+-- Try to schedule a job as superuser when it is not allowed
+SET cron.enable_superuser_jobs TO off;
+SELECT cron.schedule(job_name:='disallowed-superuser', schedule:='* * * * *', command:='drop database pg_crondbno');
+ERROR:  cannot schedule jobs as superuser
+DETAIL:  Scheduling jobs as superuser is disallowed when cron.enable_superuser_jobs is set to off.
+SELECT cron.alter_job(7, username := current_user);
+ERROR:  cannot schedule jobs as superuser
+DETAIL:  Scheduling jobs as superuser is disallowed when cron.enable_superuser_jobs is set to off.
+-- Scheduling as other users is allowed as superuser
+SELECT cron.schedule(job_name:='more vacuum', schedule:='0 12 * * *', command:='VACUUM', username:='pgcron_cront');
+ schedule 
+----------
+        8
+(1 row)
+
+SELECT cron.alter_job(7, username := 'pgcron_cront');
+ alter_job 
+-----------
+ 
 (1 row)
 
 -- cleaning

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -46,6 +46,7 @@ typedef struct CronJob
 /* global settings */
 extern char *CronHost;
 extern bool CronJobCacheValid;
+extern bool EnableSuperuserJobs;
 
 
 /* functions for retrieving job metadata */

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -3,6 +3,8 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 
+SET cron.enable_superuser_jobs TO on;
+
 -- Vacuum every day at 10:00am (GMT)
 SELECT cron.schedule('0 10 * * *', 'VACUUM');
 
@@ -99,6 +101,16 @@ SELECT username FROM cron.job where jobid=2;
 -- Create a job for another user
 SELECT cron.schedule(job_name:='his vacuum', schedule:='0 11 * * *', command:='VACUUM',username:='pgcron_cront');
 SELECT username FROM cron.job where jobid=7;
+
+-- Try to schedule a job as superuser when it is not allowed
+SET cron.enable_superuser_jobs TO off;
+
+SELECT cron.schedule(job_name:='disallowed-superuser', schedule:='* * * * *', command:='drop database pg_crondbno');
+SELECT cron.alter_job(7, username := current_user);
+
+-- Scheduling as other users is allowed as superuser
+SELECT cron.schedule(job_name:='more vacuum', schedule:='0 12 * * *', command:='VACUUM', username:='pgcron_cront');
+SELECT cron.alter_job(7, username := 'pgcron_cront');
 
 -- cleaning
 DROP EXTENSION pg_cron;

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -232,6 +232,16 @@ _PG_init(void)
 		GUC_SUPERUSER_ONLY,
 		NULL, NULL, NULL);
 
+	DefineCustomBoolVariable(
+		"cron.enable_superuser_jobs",
+		gettext_noop("Allow jobs to be scheduled as superuser"),
+		NULL,
+		&EnableSuperuserJobs,
+		true,
+		PGC_USERSET,
+		GUC_SUPERUSER_ONLY,
+		NULL, NULL, NULL);
+
 	DefineCustomStringVariable(
 		"cron.host",
 		gettext_noop("Hostname to connect to postgres."),


### PR DESCRIPTION
Per request, add an option to disallow running jobs as superuser altogether to support set ups in which there is a highly privileged user that is allowed to write to cron.job and therefore allowed to schedule jobs as other users, without implicitly granting superuser privileges.