### PR TITLE
Revoke execute on alter_job from public by default

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -119,6 +119,8 @@ ERROR:  role "pgcron_useraqwxszedc" does not exist
 -- Alter an existing job on a database that does not accept connections
 SELECT cron.alter_job(job_id:=2,database:='pgcron_dbno',username:='pgcron_cront');
 ERROR:  User pgcron_cront does not have CONNECT privilege on pgcron_dbno
+-- Make sure pgcron_cront can execute alter_job
+GRANT EXECUTE ON FUNCTION cron.alter_job(bigint,text,text,text,text,boolean) TO public;
 -- Second as non superuser
 SET SESSION AUTHORIZATION pgcron_cront;
 -- Create a job

--- a/pg_cron--1.3--1.4.sql
+++ b/pg_cron--1.3--1.4.sql
@@ -13,6 +13,9 @@ AS 'MODULE_PATHNAME', $$cron_alter_job$$;
 COMMENT ON FUNCTION cron.alter_job(bigint,text,text,text,text,boolean)
 IS 'Alter the job identified by job_id. Any option left as NULL will not be modified.';
 
+/* admin should decide whether alter_job is safe by explicitly granting execute */
+REVOKE ALL ON FUNCTION cron.alter_job(bigint,text,text,text,text,boolean) FROM public;
+
 CREATE FUNCTION cron.schedule(job_name text,
 								schedule text,
 								command text,

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -66,6 +66,9 @@ SELECT cron.schedule(job_name:='user does not exist', schedule:='0 11 * * *', co
 -- Alter an existing job on a database that does not accept connections
 SELECT cron.alter_job(job_id:=2,database:='pgcron_dbno',username:='pgcron_cront');
 
+-- Make sure pgcron_cront can execute alter_job
+GRANT EXECUTE ON FUNCTION cron.alter_job(bigint,text,text,text,text,boolean) TO public;
+
 -- Second as non superuser
 SET SESSION AUTHORIZATION pgcron_cront;
 


### PR DESCRIPTION
Not all environments that support pg_cron revoke CONNECT privileges on databases that users are not supposed to connect to, instead they rely on pg_hba.conf to control access. Hence, it seems safer to revoke alter_job privileges by default to allow those who do restrict CONNECT access to grant execute to alter_job.