### PR TITLE
add regress options to run installcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ lib*.pc
 /src/Makefile.custom
 
 pg_cron--?.?.sql
+
+log/
+results/
+src/*.bc

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ EXTVERSION = 1.3
 
 DATA_built = $(EXTENSION)--1.0.sql
 DATA = $(wildcard $(EXTENSION)--*--*.sql)
+
+REGRESS_OPTS =--temp-config=./pg_cron.conf --temp-instance=./tmp_check
 REGRESS = pg_cron-test 
 
 # compilation configuration

--- a/pg_cron.conf
+++ b/pg_cron.conf
@@ -1,0 +1,1 @@
+shared_preload_libraries = 'pg_cron'


### PR DESCRIPTION
This PR adds extra options to the pg_regress, enabling the
support to create a functional postgres instance to run the tests
without a server running.

Also updated `.gitignore` file with the files created by the pg_regress.

Signed-off-by: Sebastian Webber <sebastian@swebber.me>
Co-authored-by: Guilherme Elias <elias@ongres.com>