### PR TITLE
Support PostgreSQL 15

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -2028,7 +2028,6 @@ CronBackgroundWorker(Datum main_arg)
 	/* Post-execution cleanup. */
 	disable_timeout(STATEMENT_TIMEOUT, false);
 	CommitTransactionCommand();
-	ProcessCompletedNotifies();
 	pgstat_report_activity(STATE_IDLE, command);
 	pgstat_report_stat(true);
 


### PR DESCRIPTION
Since ProcessCompletedNotifies() is removed in 15, and there is no need
to call it for bgworker, so I think we can remove it.

Discussion: https://www.postgresql.org/message-id/flat/153243441449.1404.2274116228506175596%40wrigleys.postgresql.org
Commit: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=2e4eae87d02fef51c42c2028b65d85b9e051f9eb