### PR TITLE
Grant select to sequences to simplify pg_dump as non-superuser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # src/test/modules/pg_cron/Makefile
 
 EXTENSION = pg_cron
-EXTVERSION = 1.3
 
 DATA_built = $(EXTENSION)--1.0.sql
 DATA = $(wildcard $(EXTENSION)--*--*.sql)

--- a/pg_cron--1.4--1.4-1.sql
+++ b/pg_cron--1.4--1.4-1.sql
@@ -1,0 +1,10 @@
+/* pg_cron--1.4--1.4-1.sql */
+
+/*
+ * pg_dump will read from these sequences. Grant everyone permission
+ * to read from the sequence. That way, a user with usage on the cron
+ * schema can also do pg_dump. This does not grant write/nextval
+ * permission.
+ */
+GRANT SELECT ON SEQUENCE cron.jobid_seq TO public;
+GRANT SELECT ON SEQUENCE cron.runid_seq TO public;

--- a/pg_cron.control
+++ b/pg_cron.control
@@ -1,4 +1,4 @@
 comment = 'Job scheduler for PostgreSQL'
-default_version = '1.4'
+default_version = '1.4-1'
 module_pathname = '$libdir/pg_cron'
 relocatable = false


### PR DESCRIPTION
Doing pg_dump on the whole database as a non-superuser is a little cumbersome when pg_cron is installed.

```bash
$ pg_dump -U dumper 
pg_dump: error: query failed: ERROR:  permission denied for sequence jobid_seq           
pg_dump: error: query was: SELECT last_value, is_called FROM cron.jobid_seq   
```

By granting select on the sequences to public it becomes slightly easier.
```bash
$ pg_dump -U dumper
...
pg_dump: error: query failed: ERROR:  query would be affected by row-level security policy for table "job"
pg_dump: error: query was: COPY cron.job (jobid, schedule, command, nodename, nodeport, database, username, active, jobname) TO stdout;

$ pg_dump -U dumper --enable-row-security
...
CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA public;  

COPY cron.job (jobid, schedule, command, nodename, nodeport, database, username, active, jobname) FROM stdin;                                                                     
\.  
...
CREATE POLICY cron_job_policy ON cron.job USING ((username = CURRENT_USER));   
```

Still not ideal with the need for `--enable-row-security` (or `-N cron`) and the extra `CREATE POLICY` in the output, but slightly better than before.