### PR TITLE
fix crash after unschedule during running task

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -1745,8 +1745,16 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 		default:
 		{
 			int currentPendingRunCount = task->pendingRunCount;
+			CronJob *job = GetCronJob(jobId);
 
-			InitializeCronTask(task, jobId);
+			/*
+			 * It may happen that job was unscheduled during task execution.
+			 * In this case we keep task as-is. Otherwise, we should
+			 * re-initialize task, i.e. reset fields to initial values including
+			 * status.
+			 */
+			if (job != NULL && job->active)
+				InitializeCronTask(task, jobId);
 
 			/*
 			 * We keep the number of runs that should have started while

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -1755,6 +1755,8 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			 */
 			if (job != NULL && job->active)
 				InitializeCronTask(task, jobId);
+			else
+				task->state = CRON_TASK_WAITING;
 
 			/*
 			 * We keep the number of runs that should have started while


### PR DESCRIPTION
pg_cron can cause crash of PostgreSQL instance if task is running during "unschedule" call. Crash happens during next cycle of launcher after task completion. 
Here is stack trace:
```
(gdb) bt
#0  0x00007f5a553c49ef in ShouldRunTask (schedule=0x10, currentTime=<optimized out>, doWild=<optimized out>, doNonWild=<optimized out>) at src/pg_cron.c:945
#1  0x00007f5a553c6b1c in StartPendingRuns (task=0x2da8398, task=0x2da8398, currentTime=697539660000563, lastMinute=<optimized out>, clockProgress=CLOCK_PROGRESSED) at src/pg_cron.c:792
#2  StartAllPendingRuns (currentTime=697539660000563, taskList=0x2d63820) at src/pg_cron.c:749
#3  PgCronLauncherMain (arg=<optimized out>) at src/pg_cron.c:650
#4  0x00000000006ccfcf in StartBackgroundWorker () at bgworker.c:911
#5  0x00000000006d8f63 in do_start_bgworker (rw=0x2d170a0) at postmaster.c:5811
#6  maybe_start_bgworkers () at postmaster.c:6036
#7  0x00000000006d945e in reaper (postgres_signal_arg=<optimized out>) at postmaster.c:2903
#8  <signal handler called>
#9  0x00007f5a61ce8b23 in __select_nocancel () from /lib64/libc.so.6
#10 0x0000000000480295 in ServerLoop () at postmaster.c:1692
#11 0x00000000006dac29 in PostmasterMain (argc=argc@entry=3, argv=argv@entry=0x2cee9f0) at postmaster.c:1401
#12 0x0000000000481adf in main (argc=3, argv=0x2cee9f0) at main.c:228
```

Actually job is missing in CronJobHash while task is active. Task status was set to active during InitializeCronTask call inside CRON_TASK_DONE step of task processing. 

This patch adds check of job presence and its status before re-init of task. 

Here is test code to check issue & fix:
```
create or replace function test_cron_fnc() 
returns int 
as
$$
begin
        perform pg_sleep(1);
        perform cron.unschedule('test_cron_func');
        perform pg_sleep(1);
        return 0;
end
$$ language plpgsql;

select cron.schedule('test_cron_func','* * * * *',$$ select test_cron_fnc()$$);
```