### PR TITLE
fix: postgres cannot stop by pt_ctl when standby is stopped first

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -332,6 +332,13 @@ pg_cron_sigterm(SIGNAL_ARGS)
 	{
 		SetLatch(&MyProc->procLatch);
 	}
+
+	if (!proc_exit_inprogress)
+	{
+		InterruptPending = true;
+		ProcDiePending = true;
+	}
+	CHECK_FOR_INTERRUPTS();
 }
 
 


### PR DESCRIPTION
in stream replication with synchronous_commit=on/remote_apply/remote_write.
and then stop standby postgres. pg_cron with write sql will block primary postgres
and cannot stop by pg_ctl, only can stopped by kill -9