### PR TITLE
add PGDLLEXPORT to adapt pg 16

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -118,8 +118,8 @@ void _PG_fini(void);
 static void pg_cron_sigterm(SIGNAL_ARGS);
 static void pg_cron_sighup(SIGNAL_ARGS);
 static void pg_cron_background_worker_sigterm(SIGNAL_ARGS);
-void PgCronLauncherMain(Datum arg);
-void CronBackgroundWorker(Datum arg);
+PGDLLEXPORT void PgCronLauncherMain(Datum arg);
+PGDLLEXPORT void CronBackgroundWorker(Datum arg);
 
 static void StartAllPendingRuns(List *taskList, TimestampTz currentTime);
 static void StartPendingRuns(CronTask *task, ClockProgress clockProgress,


### PR DESCRIPTION
postgres master branch(a.k.a release 16) add a feature *Default to hidden visibility for extension libraries where possible*[1], this will cause problem when loading the pg_cron shared library.

```
ERROR:  could not find function "PgCronLauncherMain"
```

add PGDLLEXPORT can solve the problem.

[1] https://github.com/postgres/postgres/commit/089480c077056fc20fa8d8f5a3032a9dcf5ed812

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>