### PR TITLE
[typo] %s/jobId/runId/g in NextRunId

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -522,8 +522,8 @@ NextRunId(void)
 	Datum sequenceIdDatum = InvalidOid;
 	Oid savedUserId = InvalidOid;
 	int savedSecurityContext = 0;
-	Datum jobIdDatum = 0;
-	int64 jobId = 0;
+	Datum runIdDatum = 0;
+	int64 runId = 0;
 	bool failOK = true;
 	MemoryContext originalContext = CurrentMemoryContext;
 
@@ -551,17 +551,17 @@ NextRunId(void)
 	SetUserIdAndSecContext(CronExtensionOwner(), SECURITY_LOCAL_USERID_CHANGE);
 
 	/* generate new and unique colocation id from sequence */
-	jobIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
+	runIdDatum = DirectFunctionCall1(nextval_oid, sequenceIdDatum);
 
 	SetUserIdAndSecContext(savedUserId, savedSecurityContext);
 
-	jobId = DatumGetInt64(jobIdDatum);
+	runId = DatumGetInt64(runIdDatum);
 
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 	MemoryContextSwitchTo(originalContext);
 
-	return jobId;
+	return runId;
 }
 
 /*


### PR DESCRIPTION
in NextRunId, we are generating runId but not jobId, fix the typo.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>