### PR TITLE
tests: Fix compatibility with PG<=12

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -196,9 +196,9 @@ DROP TYPE IF EXISTS current_setting cascade;
 NOTICE:  type "current_setting" does not exist, skipping
 CREATE TYPE current_setting AS ENUM ('cron.database_name');
 CREATE OR REPLACE FUNCTION public.func1(text, current_setting) RETURNS text
-    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database();';
+    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database()::text;';
 CREATE OR REPLACE FUNCTION public.func1(current_setting) RETURNS text
-    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database();';
+    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database()::text;';
 CREATE CAST (current_setting AS text) WITH FUNCTION public.func1(current_setting) AS IMPLICIT;
 CREATE EXTENSION pg_cron VERSION '1.4';
 select * from public.test;

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -110,10 +110,10 @@ DROP TYPE IF EXISTS current_setting cascade;
 CREATE TYPE current_setting AS ENUM ('cron.database_name');
 
 CREATE OR REPLACE FUNCTION public.func1(text, current_setting) RETURNS text
-    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database();';
+    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database()::text;';
 
 CREATE OR REPLACE FUNCTION public.func1(current_setting) RETURNS text
-    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database();';
+    LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database()::text;';
 
 CREATE CAST (current_setting AS text) WITH FUNCTION public.func1(current_setting) AS IMPLICIT;
 


### PR DESCRIPTION
This fixes the testsuite to run with PG 12 and earlier.

ERROR:  return type mismatch in function declared to return text DETAIL:  Actual return type is name.

Close #195.