### PR TITLE
docs: standardize example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ SELECT cron.unschedule('nightly-vacuum' );
  unschedule 
 ------------
  t
-(1 row)
 
 SELECT cron.unschedule(42);
  unschedule


### PR DESCRIPTION
Output for 4 of the 5 examples does not include the row count. This removes the row count from the 5th example for consistency.