### PR TITLE
Fix variable shadowing

### DIFF
--- a/src/task_states.c
+++ b/src/task_states.c
@@ -100,7 +100,7 @@ RefreshTaskHash(void)
 	{
 		CronJob *job = (CronJob *) lfirst(jobCell);
 
-		CronTask *task = GetCronTask(job->jobId);
+		task = GetCronTask(job->jobId);
 		task->isActive = job->active;
 	}
 


### PR DESCRIPTION
This pull request fixes #214 

Previously:
```
$ make
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/usr/local/pgsql/include -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal  -D_GNU_SOURCE   -c -o src/pg_cron.o src/pg_cron.c -MMD -MP -MF .deps/pg_cron.Po
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/usr/local/pgsql/include -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal  -D_GNU_SOURCE   -c -o src/job_metadata.o src/job_metadata.c -MMD -MP -MF .deps/job_metadata.Po
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/usr/local/pgsql/include -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal  -D_GNU_SOURCE   -c -o src/misc.o src/misc.c -MMD -MP -MF .deps/misc.Po
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/usr/local/pgsql/include -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal  -D_GNU_SOURCE   -c -o src/task_states.o src/task_states.c -MMD -MP -MF .deps/task_states.Po
src/task_states.c: In function ‘RefreshTaskHash’:
src/task_states.c:103:13: error: declaration of ‘task’ shadows a previous local [-Werror=shadow=compatible-local]
   CronTask *task = GetCronTask(job->jobId);
             ^~~~
src/task_states.c:83:12: note: shadowed declaration is here
  CronTask *task = NULL;
            ^~~~
cc1: all warnings being treated as errors
/usr/local/pgsql/lib/pgxs/src/makefiles/../../src/Makefile.global:948: recipe for target 'src/task_states.o' failed
make: *** [src/task_states.o] Error 1

```

Now:
```
$ make
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/usr/local/pgsql/include -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal  -D_GNU_SOURCE   -c -o src/task_states.o src/task_states.c -MMD -MP -MF .deps/task_states.Po
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/usr/local/pgsql/include -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal  -D_GNU_SOURCE   -c -o src/entry.o src/entry.c -MMD -MP -MF .deps/entry.Po
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -g -Wshadow=compatible-local -fPIC -shared -o pg_cron.so src/pg_cron.o src/job_metadata.o src/misc.o src/task_states.o src/entry.o -L/usr/local/pgsql/lib    -Wl,--as-needed -Wl,-rpath,'/usr/local/pgsql/lib',--enable-new-dtags  -L/usr/local/pgsql/lib -lpq 
cat pg_cron.sql > pg_cron--1.0.sql
```