### PR TITLE
Fix issue #200 preventing concurrent background workers

### DIFF
--- a/include/task_states.h
+++ b/include/task_states.h
@@ -16,6 +16,7 @@
 #include "libpq-fe.h"
 #include "postmaster/bgworker.h"
 #include "storage/dsm.h"
+#include "storage/shm_mq.h"
 #include "utils/timestamp.h"
 
 
@@ -52,6 +53,7 @@ typedef struct CronTask
 	bool isActive;
 	char *errorMessage;
 	bool freeErrorMessage;
+	shm_mq_handle *sharedMemoryQueue;
 	dsm_segment *seg;
 	BackgroundWorkerHandle handle;
 } CronTask;


### PR DESCRIPTION
We should pass `nowait` to `shm_mq_receive` to continue while the background worker is running.

Closes #200 
Closes #229