### PR TITLE
Make job name a text field

### DIFF
--- a/include/cron_job.h
+++ b/include/cron_job.h
@@ -27,7 +27,7 @@ typedef struct FormData_cron_job
 	text database;
 	text userName;
 	bool active;
-	Name jobName;
+	text jobName;
 #endif
 } FormData_cron_job;
 

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -39,7 +39,7 @@ typedef struct CronJob
 	char *database;
 	char *userName;
 	bool active;
-	Name jobName;
+	char *jobName;
 } CronJob;
 
 

--- a/pg_cron--1.4-1--1.5.sql
+++ b/pg_cron--1.4-1--1.5.sql
@@ -1,0 +1,9 @@
+ALTER TABLE cron.job ALTER COLUMN jobname TYPE text;
+
+DROP FUNCTION cron.unschedule(name);
+CREATE FUNCTION cron.unschedule(job_name text)
+    RETURNS bool
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$cron_unschedule_named$$;
+COMMENT ON FUNCTION cron.unschedule(text)
+    IS 'unschedule a pg_cron job';

--- a/pg_cron.control
+++ b/pg_cron.control
@@ -1,4 +1,5 @@
 comment = 'Job scheduler for PostgreSQL'
-default_version = '1.4-1'
+default_version = '1.5'
 module_pathname = '$libdir/pg_cron'
 relocatable = false
+schema = pg_catalog


### PR DESCRIPTION
Job name being a name field is causing some issues.

This will require an ALTER EXTENSION / is likely to cause some issues when the schema is stale.

Fixes #196