### PR TITLE
Remove pg_stat_activity reporting from job metadata queries

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -844,7 +844,6 @@ LoadCronJobList(void)
 		PopActiveSnapshot();
 		CommitTransactionCommand();
 		MemoryContextSwitchTo(originalContext);
-		pgstat_report_activity(STATE_IDLE, NULL);
 
 		return NIL;
 	}
@@ -897,7 +896,6 @@ LoadCronJobList(void)
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 	MemoryContextSwitchTo(originalContext);
-	pgstat_report_activity(STATE_IDLE, NULL);
 
 	return jobList;
 }
@@ -1082,8 +1080,6 @@ InsertJobRunDetail(int64 runId, int64 *jobId, char *database, char *username, ch
 	argTypes[5] = TEXTOID;
 	argValues[5] = CStringGetTextDatum(status);
 
-	pgstat_report_activity(STATE_RUNNING, querybuf.data);
-
 	if(SPI_execute_with_args(querybuf.data,
 		argCount, argTypes, argValues, NULL, false, 1) != SPI_OK_INSERT)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
@@ -1094,7 +1090,6 @@ InsertJobRunDetail(int64 runId, int64 *jobId, char *database, char *username, ch
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 	MemoryContextSwitchTo(originalContext);
-	pgstat_report_activity(STATE_IDLE, NULL);
 }
 
 void
@@ -1186,8 +1181,6 @@ UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_messa
 	/* and add the where clause */
 	appendStringInfo(&querybuf, " where runid = $%d", i);
 
-	pgstat_report_activity(STATE_RUNNING, querybuf.data);
-
 	if(SPI_execute_with_args(querybuf.data,
 		i, argTypes, argValues, NULL, false, 1) != SPI_OK_UPDATE)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
@@ -1198,7 +1191,6 @@ UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_messa
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 	MemoryContextSwitchTo(originalContext);
-	pgstat_report_activity(STATE_IDLE, NULL);
 }
 
 
@@ -1396,8 +1388,6 @@ MarkPendingRunsAsFailed(void)
 		, CRON_SCHEMA_NAME, JOB_RUN_DETAILS_TABLE_NAME, GetCronStatus(CRON_STATUS_FAILED), GetCronStatus(CRON_STATUS_STARTING), GetCronStatus(CRON_STATUS_RUNNING));
 
 
-	pgstat_report_activity(STATE_RUNNING, querybuf.data);
-
 	if (SPI_exec(querybuf.data, 0) != SPI_OK_UPDATE)
 		elog(ERROR, "SPI_exec failed: %s", querybuf.data);
 
@@ -1407,7 +1397,6 @@ MarkPendingRunsAsFailed(void)
 	PopActiveSnapshot();
 	CommitTransactionCommand();
 	MemoryContextSwitchTo(originalContext);
-	pgstat_report_activity(STATE_IDLE, NULL);
 }
 
 char *


### PR DESCRIPTION
Showing internal implementation details in pg_stat_activity mostly causes confusion, plus it's not used consistently, removing.