### PR TITLE
Add possibility to schedule jobs by interval in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What is pg_cron?
 
-pg_cron is a simple cron-based job scheduler for PostgreSQL (10 or higher) that runs inside the database as an extension. It uses the same syntax as regular cron, but it allows you to schedule PostgreSQL commands directly from the database:
+pg_cron is a simple cron-based job scheduler for PostgreSQL (10 or higher) that runs inside the database as an extension. It uses the same syntax as regular cron, but it allows you to schedule PostgreSQL commands directly from the database. You can also use '[1-59] seconds' to schedule a job based on an interval.
 
 ```sql
 -- Delete old data on Saturday at 3:30am (GMT)
@@ -41,6 +41,9 @@ SELECT cron.schedule_in_database('weekly-vacuum', '0 4 * * 0', 'VACUUM', 'some_o
  schedule
 ----------
        44
+
+-- Call a stored procedure every 5 seconds
+SELECT cron.schedule('process-updates', '5 seconds', 'CALL process_updates()'); 
 ```
 
 pg_cron can run multiple jobs in parallel, but it runs at most one instance of a job at a time. If a second run is supposed to start before the first one finishes, then the second run is queued and started as soon as the first run completes.

--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -29,9 +29,35 @@ SELECT cron.unschedule(1);
 -- Invalid input: input too long
 SELECT cron.schedule(repeat('a', 1000), '');
 ERROR:  invalid schedule: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+-- Invalid input: missing parts
+SELECT cron.schedule('* * * *', 'SELECT 1'); 
+ERROR:  invalid schedule: * * * *
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+-- Invalid input: trailing characters
+SELECT cron.schedule('5 secondc', 'SELECT 1'); 
+ERROR:  invalid schedule: 5 secondc
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+SELECT cron.schedule('50 seconds c', 'SELECT 1'); 
+ERROR:  invalid schedule: 50 seconds c
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+-- Invalid input: seconds out of range
+SELECT cron.schedule('-1 seconds', 'SELECT 1'); 
+ERROR:  invalid schedule: -1 seconds
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+SELECT cron.schedule('0 seconds', 'SELECT 1'); 
+ERROR:  invalid schedule: 0 seconds
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+SELECT cron.schedule('60 seconds', 'SELECT 1'); 
+ERROR:  invalid schedule: 60 seconds
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+SELECT cron.schedule('10000000000 seconds', 'SELECT 1'); 
+ERROR:  invalid schedule: 10000000000 seconds
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
 -- Try to update pg_cron on restart
 SELECT cron.schedule('@restar', 'ALTER EXTENSION pg_cron UPDATE');
 ERROR:  invalid schedule: @restar
+HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
 SELECT cron.schedule('@restart', 'ALTER EXTENSION pg_cron UPDATE');
  schedule 
 ----------
@@ -200,11 +226,45 @@ CREATE OR REPLACE FUNCTION public.func1(text, current_setting) RETURNS text
 CREATE OR REPLACE FUNCTION public.func1(current_setting) RETURNS text
     LANGUAGE sql volatile AS 'INSERT INTO test(data) VALUES (current_user); SELECT current_database()::text;';
 CREATE CAST (current_setting AS text) WITH FUNCTION public.func1(current_setting) AS IMPLICIT;
-CREATE EXTENSION pg_cron VERSION '1.4';
+CREATE EXTENSION pg_cron;
 select * from public.test;
  data 
 ------
 (0 rows)
+
+-- valid interval jobs
+SELECT cron.schedule('1 second', 'SELECT 1'); 
+ schedule 
+----------
+        1
+(1 row)
+
+SELECT cron.schedule(' 30 sEcOnDs ', 'SELECT 1'); 
+ schedule 
+----------
+        2
+(1 row)
+
+SELECT cron.schedule('59 seconds', 'SELECT 1'); 
+ schedule 
+----------
+        3
+(1 row)
+
+SELECT cron.schedule('17  seconds ', 'SELECT 1'); 
+ schedule 
+----------
+        4
+(1 row)
+
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
+ jobid | jobname |   schedule   | command  
+-------+---------+--------------+----------
+     1 |         | 1 second     | SELECT 1
+     2 |         |  30 sEcOnDs  | SELECT 1
+     3 |         | 59 seconds   | SELECT 1
+     4 |         | 17  seconds  | SELECT 1
+(4 rows)
 
 -- cleaning
 DROP EXTENSION pg_cron;

--- a/include/cron.h
+++ b/include/cron.h
@@ -159,7 +159,7 @@ typedef	struct _entry {
 	uid_t		uid;	
 	gid_t		gid;
 	char		**envp;
-	char		*cmd;
+	int         secondsInterval;
 	bitstr_t	bit_decl(minute, MINUTE_COUNT);
 	bitstr_t	bit_decl(hour,   HOUR_COUNT);
 	bitstr_t	bit_decl(dom,    DOM_COUNT);

--- a/include/task_states.h
+++ b/include/task_states.h
@@ -49,6 +49,8 @@ typedef struct CronTask
 	PGconn *connection;
 	PostgresPollingStatusType pollingStatus;
 	TimestampTz startDeadline;
+	TimestampTz lastStartTime;
+	uint32 secondsInterval;
 	bool isSocketReady;
 	bool isActive;
 	char *errorMessage;

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -13,6 +13,19 @@ SELECT cron.unschedule(1);
 -- Invalid input: input too long
 SELECT cron.schedule(repeat('a', 1000), '');
 
+-- Invalid input: missing parts
+SELECT cron.schedule('* * * *', 'SELECT 1'); 
+
+-- Invalid input: trailing characters
+SELECT cron.schedule('5 secondc', 'SELECT 1'); 
+SELECT cron.schedule('50 seconds c', 'SELECT 1'); 
+
+-- Invalid input: seconds out of range
+SELECT cron.schedule('-1 seconds', 'SELECT 1'); 
+SELECT cron.schedule('0 seconds', 'SELECT 1'); 
+SELECT cron.schedule('60 seconds', 'SELECT 1'); 
+SELECT cron.schedule('10000000000 seconds', 'SELECT 1'); 
+
 -- Try to update pg_cron on restart
 SELECT cron.schedule('@restar', 'ALTER EXTENSION pg_cron UPDATE');
 SELECT cron.schedule('@restart', 'ALTER EXTENSION pg_cron UPDATE');
@@ -117,8 +130,15 @@ CREATE OR REPLACE FUNCTION public.func1(current_setting) RETURNS text
 
 CREATE CAST (current_setting AS text) WITH FUNCTION public.func1(current_setting) AS IMPLICIT;
 
-CREATE EXTENSION pg_cron VERSION '1.4';
+CREATE EXTENSION pg_cron;
 select * from public.test;
+
+-- valid interval jobs
+SELECT cron.schedule('1 second', 'SELECT 1'); 
+SELECT cron.schedule(' 30 sEcOnDs ', 'SELECT 1'); 
+SELECT cron.schedule('59 seconds', 'SELECT 1'); 
+SELECT cron.schedule('17  seconds ', 'SELECT 1'); 
+SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
 
 -- cleaning
 DROP EXTENSION pg_cron;

--- a/src/entry.c
+++ b/src/entry.c
@@ -44,8 +44,6 @@ static int	set_element(bitstr_t *, int, int, int);
 void
 free_entry(entry *e)
 {
-	if (e->cmd)
-		free(e->cmd);
 	free(e);
 }
 

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -673,7 +673,8 @@ StartAllPendingRuns(List *taskList, TimestampTz currentTime)
 			CronJob *cronJob = GetCronJob(task->jobId);
 			entry *schedule = &cronJob->schedule;
 
-			if (schedule->flags & WHEN_REBOOT)
+			if (schedule->flags & WHEN_REBOOT &&
+				task->isActive)
 			{
 				task->pendingRunCount += 1;
 			}

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -683,6 +683,27 @@ StartAllPendingRuns(List *taskList, TimestampTz currentTime)
 		RebootJobsScheduled = true;
 	}
 
+	foreach(taskCell, taskList)
+	{
+		CronTask *task = (CronTask *) lfirst(taskCell);
+
+		if (task->secondsInterval > 0 && task->isActive)
+		{
+			/*
+			 * For interval jobs, if a task takes longer than the interval,
+			 * we only queue up once. So if a task that is supposed to run
+			 * every 30 seconds takes 5 minutes, we start another run
+			 * immediately after 5 minutes, but then return to regular cadence.
+			 */
+			if (task->pendingRunCount == 0 &&
+				TimestampDifferenceExceeds(task->lastStartTime, currentTime,
+										   task->secondsInterval * 1000))
+			{
+				task->pendingRunCount += 1;
+			}
+		}
+	}
+
 	if (lastMinute == 0)
 	{
 		lastMinute = TimestampMinuteStart(currentTime);
@@ -1052,6 +1073,22 @@ PollForTasks(List *taskList)
 
 		if (task->state == CRON_TASK_WAITING && task->pendingRunCount == 0)
 		{
+			/*
+			 * Make sure we do not wait past the next run time of an interval
+			 * job.
+			 */
+			if (task->secondsInterval > 0)
+			{
+				TimestampTz nextRunTime =
+					TimestampTzPlusMilliseconds(task->lastStartTime,
+												task->secondsInterval * 1000);
+
+				if (TimestampDifferenceExceeds(nextRunTime, nextEventTime, 0))
+				{
+					nextEventTime = nextRunTime;
+				}
+			}
+
 			/* don't poll idle tasks */
 			continue;
 		}
@@ -1122,9 +1159,11 @@ PollForTasks(List *taskList)
 	pollTimeout = waitSeconds * 1000 + waitMicros / 1000;
 	if (pollTimeout <= 0)
 	{
-		pfree(polledTasks);
-		pfree(pollFDs);
-		return;
+		/*
+		 * Interval jobs might frequently be overdue, inject a small
+		 * 1ms wait to avoid getting into a tight loop.
+		 */
+		pollTimeout = 1;
 	}
 	else if (pollTimeout > MaxWait)
 	{
@@ -1237,6 +1276,8 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 				task->state = CRON_TASK_BGW_START;
 			else
 				task->state = CRON_TASK_START;
+
+			task->lastStartTime = currentTime;
 
 			RunningTaskCount++;
 

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -102,6 +102,7 @@ RefreshTaskHash(void)
 
 		task = GetCronTask(job->jobId);
 		task->isActive = job->active;
+		task->secondsInterval = job->schedule.secondsInterval;
 	}
 
 	CronJobCacheValid = true;
@@ -122,6 +123,13 @@ GetCronTask(int64 jobId)
 	if (!isPresent)
 	{
 		InitializeCronTask(task, jobId);
+
+		/*
+		 * We only initialize last run when entering into the hash.
+		 * The net effect is that the timer for the first run of an
+		 * interval job starts when pg_cron first learns about the job.
+		 */
+		task->lastStartTime = GetCurrentTimestamp();
 	}
 
 	return task;


### PR DESCRIPTION
By popular demand, fixes #6.

Extends the schedule syntax to allow defining jobs based on an interval in seconds that starts when pg_cron learns about the job, shortly after scheduling or server boot. The interval is measured from the start of the last run. If a run takes longer than the interval, the next run starts immediately after, which resets the interval timer.

We opted to define a job purely based on an interval because adding another part to the cron schedule would make the schedule hard to read, incompatible with typical crontab tools, and the level of control over when in the week the "per x second" job happens seems unnecessary. Moreover, we usually cannot guarantee when a job happens down to the second on busy servers, so we'll make no attempt to do so.

Syntax is as follows, inspired by `interval` syntax, but only positive whole seconds are supported.
```
SELECT cron.schedule('check-news', '5 seconds', 'SELECT check_news()');
```