### PR TITLE
Use correct time type on 32-bit systems

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -948,7 +948,7 @@ static bool
 ShouldRunTask(entry *schedule, TimestampTz currentTime, bool doWild,
 			  bool doNonWild)
 {
-	time_t currentTime_t = timestamptz_to_time_t(currentTime);
+	pg_time_t currentTime_t = timestamptz_to_time_t(currentTime);
 	struct pg_tm* tm = pg_localtime(&currentTime_t, pg_tzset(cron_timezone));
 
 	int minute = tm->tm_min -FIRST_MINUTE;


### PR DESCRIPTION
time_t depends on the current architecture:

```
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-uninitialized -Wno-implicit-fallthrough -Iinclude -I/usr/include/postgresql -I. -I./ -I/usr/include/postgresql/14/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2   -c -o src/pg_cron.o src/pg_cron.c
src/pg_cron.c: In function ‘ShouldRunTask’:
src/pg_cron.c:948:41: error: passing argument 1 of ‘pg_localtime’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  948 |         struct pg_tm* tm = pg_localtime(&currentTime_t, pg_tzset(cron_timezone));
      |                                         ^~~~~~~~~~~~~~
      |                                         |
      |                                         time_t * {aka long int *}
In file included from /usr/include/postgresql/14/server/miscadmin.h:29,
                 from src/pg_cron.c:20:
/usr/include/postgresql/14/server/pgtime.h:48:52: note: expected ‘const pg_time_t *’ {aka ‘const long long int *’} but argument is of type ‘time_t *’ {aka ‘long int *’}
   48 | extern struct pg_tm *pg_localtime(const pg_time_t *timep, const pg_tz *tz);
      |                                   ~~~~~~~~~~~~~~~~~^~~~~
```