### PR TITLE
Fix jobname field handling

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -985,7 +985,7 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 			/* Handle the column type change introduced in 1.5 */
 			if (TupleDescAttr(tupleDescriptor, Anum_cron_job_jobname - 1)->atttypid == NAMEOID)
 			{
-				job->jobName = (DatumGetName(jobName))->data;
+				job->jobName = pstrdup(NameStr(*DatumGetName(jobName)));
 			}
 			else
 			{

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -982,6 +982,7 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 									 tupleDescriptor, &isJobNameNull);
 		if (!isJobNameNull)
 		{
+			/* Handle the column type change introduced in 1.5 */
 			if (TupleDescAttr(tupleDescriptor, Anum_cron_job_jobname - 1)->atttypid == NAMEOID)
 			{
 				job->jobName = (DatumGetName(jobName))->data;

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -982,7 +982,14 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 									 tupleDescriptor, &isJobNameNull);
 		if (!isJobNameNull)
 		{
-			job->jobName = TextDatumGetCString(jobName);
+			if (TupleDescAttr(tupleDescriptor, Anum_cron_job_jobname - 1)->atttypid == NAMEOID)
+			{
+				job->jobName = (DatumGetName(jobName))->data;
+			}
+			else
+			{
+				job->jobName = TextDatumGetCString(jobName);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
After job name was converted to a text field in 6fc9ca9 there is a problem in updating the extension from the versions where the field is of type name. Namely: when postgres is started - the extenision is still not updated, thus, the column type is not yet altered, pg_cron launcher gets a Segmentation Fault during the attempt to convert a heap tuple from cron.job table to a CronJob struct.

Steps to reproduce:
1. Compile and install pg_cron pre-1.5 (e.g. 1.4-1)
2. Schedule a job with a name
3. Compile and install pg_cron 1.5
4. Restart cluster

```
,LOG,00000,"background worker ""pg_cron launcher"" (PID 796233) was terminated by signal 11: Segmentation fault",,,,,,,,,"","postmaster",,0
```

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x10e5b4000)
  * frame #0: 0x00000001aa89a700 libsystem_platform.dylib`_platform_memmove + 96
    frame #1: 0x0000000104ff9d40 postgres`text_to_cstring(t=0x0000000105f033bb) at varlena.c:230:2 [opt]
    frame #2: 0x000000010570e018 pg_cron.so`LoadCronJobList at job_metadata.c:976:19 [opt]
    frame #3: 0x000000010570d77c pg_cron.so`LoadCronJobList at job_metadata.c:882:9 [opt]
    frame #4: 0x0000000105711310 pg_cron.so`RefreshTaskHash at task_states.c:96:12 [opt]
    frame #5: 0x000000010570f304 pg_cron.so`PgCronLauncherMain(arg=<unavailable>) at pg_cron.c:624:4 [opt]
 ...
```

```
(lldb) f 2
frame #2: 0x000000010570e018 pg_cron.so`LoadCronJobList at job_metadata.c:976:19 [opt]
   973 										 tupleDescriptor, &isJobNameNull);
   974 			if (!isJobNameNull)
   975 			{
-> 976 				job->jobName = TextDatumGetCString(jobName);
   977 			}
   978 			else
   979 	
   ```
   
   Hope this fix makes sense. There maybe is a better approach to solve the issue. In any case, wanted to highlight the problem 