### PR TITLE
Test latest version instead of hardcoding 1.4

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -5,13 +5,7 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.0
 (1 row)
 
-ALTER EXTENSION pg_cron UPDATE TO '1.4';
-SELECT extversion FROM pg_extension WHERE extname='pg_cron';
- extversion 
-------------
- 1.4
-(1 row)
-
+ALTER EXTENSION pg_cron UPDATE;
 -- Vacuum every day at 10:00am (GMT)
 SELECT cron.schedule('0 10 * * *', 'VACUUM');
  schedule 

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -1,7 +1,6 @@
 CREATE EXTENSION pg_cron VERSION '1.0';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
-ALTER EXTENSION pg_cron UPDATE TO '1.4';
-SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+ALTER EXTENSION pg_cron UPDATE;
 
 -- Vacuum every day at 10:00am (GMT)
 SELECT cron.schedule('0 10 * * *', 'VACUUM');


### PR DESCRIPTION
The 1.4 version of the SQL scripts are no longer compatible with the C code since cron_unschedule_named expects "text" as input now.

Instead of hardcoding '1.4', simply upgrade to the most recent version. Also drop the test for extversion after the upgrade since this value is prone to be missed on future releases.

Problem was visible on big-endian architectures.

https://github.com/citusdata/pg_cron/issues/267

Close #267.