### PR TITLE
fix memory corruption bug of cron module

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -38,7 +38,8 @@ typedef	enum ecode {
 static int	get_list(bitstr_t *, int, int, char *[], int, FILE *),
 		get_range(bitstr_t *, int, int, char *[], int, FILE *),
 		get_number(int *, int, char *[], int, FILE *);
-static int	set_element(bitstr_t *, int, int, int);
+static int	set_element(bitstr_t *, int, int, int),
+		set_range(bitstr_t *, int, int, int, int, int);
 
 
 void
@@ -124,38 +125,63 @@ parse_cron_entry(char *schedule)
 		if (!strcmp("reboot", cmd) || !strcmp("restart", cmd)) {
 			e->flags |= WHEN_REBOOT;
 		} else if (!strcmp("yearly", cmd) || !strcmp("annually", cmd)){
-			bit_set(e->minute, 0);
-			bit_set(e->hour, 0);
-			bit_set(e->dom, 0);
-			bit_set(e->month, 0);
-			bit_nset(e->dow, 0, (LAST_DOW-FIRST_DOW+1));
-                        e->flags |= DOW_STAR;
+			set_element(e->minute, FIRST_MINUTE, LAST_MINUTE,
+				    FIRST_MINUTE);
+			set_element(e->hour, FIRST_HOUR, LAST_HOUR,
+				    FIRST_HOUR);
+			set_element(e->dom, FIRST_DOM, LAST_DOM,
+				    FIRST_DOM);
+			set_element(e->month, FIRST_MONTH, LAST_MONTH,
+				    FIRST_MINUTE);
+			set_range(e->dow, FIRST_DOW, LAST_DOW,
+				  FIRST_DOW, LAST_DOW, 1);
+			e->flags |= DOW_STAR;
 		} else if (!strcmp("monthly", cmd)) {
-			bit_set(e->minute, 0);
-			bit_set(e->hour, 0);
-			bit_set(e->dom, 0);
-			bit_nset(e->month, 0, (LAST_MONTH-FIRST_MONTH+1));
-			bit_nset(e->dow, 0, (LAST_DOW-FIRST_DOW+1));
-                        e->flags |= DOW_STAR;
+			set_element(e->minute, FIRST_MINUTE, LAST_MINUTE,
+				    FIRST_MINUTE);
+			set_element(e->hour, FIRST_HOUR, LAST_HOUR,
+				    FIRST_HOUR);
+			set_element(e->dom, FIRST_DOM, LAST_DOM,
+				    FIRST_DOM);
+			set_range(e->month, FIRST_MONTH, LAST_MONTH,
+				  FIRST_MONTH, LAST_MONTH, 1);
+			set_range(e->dow, FIRST_DOW, LAST_DOW,
+				  FIRST_DOW, LAST_DOW, 1);
+			e->flags |= DOW_STAR;
 		} else if (!strcmp("weekly", cmd)) {
-			bit_set(e->minute, 0);
-			bit_set(e->hour, 0);
-			bit_nset(e->dom, 0, (LAST_DOM-FIRST_DOM+1));
-			e->flags |= DOM_STAR;
-			bit_nset(e->month, 0, (LAST_MONTH-FIRST_MONTH+1));
-			bit_nset(e->dow, 0,0);
+			set_element(e->minute, FIRST_MINUTE, LAST_MINUTE,
+				    FIRST_MINUTE);
+			set_element(e->hour, FIRST_HOUR, LAST_HOUR,
+				    FIRST_HOUR);
+			set_range(e->dom, FIRST_DOM, LAST_DOM,
+				  FIRST_DOM, LAST_DOM, 1);
+			set_range(e->month, FIRST_MONTH, LAST_MONTH,
+				  FIRST_MONTH, LAST_MONTH, 1);
+			set_element(e->dow, FIRST_DOW, LAST_DOW,
+				    FIRST_DOW);
+			e->flags |= DOW_STAR;
 		} else if (!strcmp("daily", cmd) || !strcmp("midnight", cmd)) {
-			bit_set(e->minute, 0);
-			bit_set(e->hour, 0);
-			bit_nset(e->dom, 0, (LAST_DOM-FIRST_DOM+1));
-			bit_nset(e->month, 0, (LAST_MONTH-FIRST_MONTH+1));
-			bit_nset(e->dow, 0, (LAST_DOW-FIRST_DOW+1));
+			set_element(e->minute, FIRST_MINUTE, LAST_MINUTE,
+				    FIRST_MINUTE);
+			set_element(e->hour, FIRST_HOUR, LAST_HOUR,
+				    FIRST_HOUR);
+			set_range(e->dom, FIRST_DOM, LAST_DOM,
+				  FIRST_DOM, LAST_DOM, 1);
+			set_range(e->month, FIRST_MONTH, LAST_MONTH,
+				  FIRST_MONTH, LAST_MONTH, 1);
+			set_range(e->dow, FIRST_DOW, LAST_DOW,
+				  FIRST_DOW, LAST_DOW, 1);
 		} else if (!strcmp("hourly", cmd)) {
-			bit_set(e->minute, 0);
-			bit_nset(e->hour, 0, (LAST_HOUR-FIRST_HOUR+1));
-			bit_nset(e->dom, 0, (LAST_DOM-FIRST_DOM+1));
-			bit_nset(e->month, 0, (LAST_MONTH-FIRST_MONTH+1));
-			bit_nset(e->dow, 0, (LAST_DOW-FIRST_DOW+1));
+			set_element(e->minute, FIRST_MINUTE, LAST_MINUTE,
+				    FIRST_MINUTE);
+			set_range(e->hour, FIRST_HOUR, LAST_HOUR,
+				  FIRST_HOUR, LAST_HOUR, 1);
+			set_range(e->dom, FIRST_DOM, LAST_DOM,
+				  FIRST_DOM, LAST_DOM, 1);
+			set_range(e->month, FIRST_MONTH, LAST_MONTH,
+				  FIRST_MONTH, LAST_MONTH, 1);
+			set_range(e->dow, FIRST_DOW, LAST_DOW,
+				  FIRST_DOW, LAST_DOW, 1);
 			e->flags |= HR_STAR;
 		} else {
 			ecode = e_timespec;
@@ -262,7 +288,7 @@ get_list(bits, low, high, names, ch, file)
 
 	/* clear the bit string, since the default is 'off'.
 	 */
-	bit_nclear(bits, 0, (high-low+1));
+	bit_nclear(bits, 0, (high-low));
 
 	/* process all ranges
 	 */
@@ -297,7 +323,6 @@ get_range(bits, low, high, names, ch, file)
 	/* range = number | number "-" number [ "/" number ]
 	 */
 
-	register int	i;
 	auto int	num1, num2, num3;
 
 	Debug(DPARS|DEXT, ("get_range()...entering, exit won't show\n"))
@@ -381,9 +406,10 @@ get_range(bits, low, high, names, ch, file)
 	 * proposed conceptually by bob@acornrc, syntactically
 	 * designed then implemented by paul vixie).
 	 */
-	for (i = num1;  i <= num2;  i += num3)
-		if (EOF == set_element(bits, low, high, i))
-			return EOF;
+	if (EOF == set_range(bits, low, high, num1, num2, num3)) {
+		unget_char(ch, file);
+		return EOF;
+	}
 
 	return ch;
 }
@@ -460,6 +486,27 @@ set_element(bits, low, high, number)
 	if (number < low || number > high)
 		return EOF;
 
-	bit_set(bits, (number-low));
+	number -= low;
+
+	bit_set(bits, number);
+	return OK;
+}
+
+static int
+set_range(bitstr_t *bits, int low, int high, int start, int stop, int step) {
+	Debug(DPARS|DEXT, ("set_range(?,%d,%d,%d,%d,%d)\n",
+			   low, high, start, stop, step))
+
+	if (start < low || stop > high)
+		return EOF;
+	start -= low;
+	stop -= low;
+
+	if (step == 1) {
+		bit_nset(bits, start, stop);
+	} else {
+		for (int i = start; i <= stop; i += step)
+			bit_set(bits, i);
+	}
 	return OK;
 }


### PR DESCRIPTION
I found a bug of vixie cron, which bit_nset and bit_nclear are used to set and clean bits of range [start, stop], for `dow` and `hour`, they use 8 bits and 24bits, the following statement will write the next byte since the pass the length instead of the stop position, which will corrupt the memory.

bit_nset(e->hour, 0, (LAST_HOUR-FIRST_HOUR+1));
bit_nset(e->dow, 0, (LAST_DOW-FIRST_DOW+1));
bit_nclear(bits, 0, (high-low+1));

Paul vixie(the author of vixie cron) fix this with some code refactory, this patch just backport it back to pg_cron.

The original PRs:

1. https://github.com/vixie/cron/pull/16
2. https://github.com/vixie/cron/pull/18