### PR TITLE
fix warning- "declaration shadows a  previous local"

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -1507,11 +1507,12 @@ static entry *
 ParseSchedule(char *scheduleText)
 {
 	uint32 secondsInterval = 0;
+	entry *schedule;
 
 	/*
 	 * First try to parse as a cron schedule.
 	 */
-	entry *schedule = parse_cron_entry(scheduleText);
+	schedule = parse_cron_entry(scheduleText);
 	if (schedule != NULL)
 	{
 		/* valid cron schedule */
@@ -1523,7 +1524,7 @@ ParseSchedule(char *scheduleText)
 	 */
 	if (TryParseInterval(scheduleText, &secondsInterval))
 	{
-		entry *schedule = calloc(sizeof(entry), sizeof(char));
+		schedule = calloc(sizeof(entry), sizeof(char));
 		schedule->secondsInterval = secondsInterval;
 		return schedule;
 	}


### PR DESCRIPTION
_entry *schedule_ local variable is declared twice in ParseSchedule.

src/job_metadata.c: In function ‘ParseSchedule’:
src/job_metadata.c:1526:10: error: declaration of ‘schedule’ shadows a previous local [-Werror=shadow=compatible-local]
 1526 |   entry *schedule = calloc(sizeof(entry), sizeof(char));
      |          ^~~~~~~~
src/job_metadata.c:1514:9: note: shadowed declaration is here
 1514 |  entry *schedule = parse_cron_entry(scheduleText);
      |         ^~~~~~~~
cc1: all warnings being treated as errors
make: *** [../../src/Makefile.global:949: src/job_metadata.o] Error 1