### PR TITLE
Convert K&R function definitions

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -266,12 +266,12 @@ parse_cron_entry(char *schedule)
 
 
 static int
-get_list(bits, low, high, names, ch, file)
-	bitstr_t	*bits;		/* one bit per flag, default=FALSE */
-	int		low, high;	/* bounds, impl. offset for bitstr */
-	char		*names[];	/* NULL or *[] of names for these elements */
-	int		ch;		/* current character being processed */
-	FILE		*file;		/* file being read */
+get_list(bitstr_t *bits, int low, int high, char *names[], int ch, FILE *file)
+	/* bitstr_t	*bits; */		/* one bit per flag, default=FALSE */
+	/* int		low, high; */	/* bounds, impl. offset for bitstr */
+	/* char		*names[]; */	/* NULL or *[] of names for these elements */
+	/* int		ch; */		/* current character being processed */
+	/* FILE		*file; */		/* file being read */
 {
 	register int	done;
 
@@ -313,12 +313,12 @@ get_list(bits, low, high, names, ch, file)
 
 
 static int
-get_range(bits, low, high, names, ch, file)
-	bitstr_t	*bits;		/* one bit per flag, default=FALSE */
-	int		low, high;	/* bounds, impl. offset for bitstr */
-	char		*names[];	/* NULL or names of elements */
-	int		ch;		/* current character being processed */
-	FILE 		*file;		/* file being read */
+get_range(bitstr_t *bits, int low, int high, char *names[], int ch, FILE *file)
+	/* bitstr_t	*bits;		one bit per flag, default=FALSE */
+	/* int		low, high;	bounds, impl. offset for bitstr */
+	/* char		*names[];	NULL or names of elements */
+	/* int		ch;		current character being processed */
+	/* FILE 		*file;		file being read */
 {
 	/* range = number | number "-" number [ "/" number ]
 	 */
@@ -416,12 +416,12 @@ get_range(bits, low, high, names, ch, file)
 
 
 static int
-get_number(numptr, low, names, ch, file)
-	int	*numptr;	/* where does the result go? */
-	int	low;		/* offset applied to result if symbolic enum used */
-	char	*names[];	/* symbolic names, if any, for enums */
-	int	ch;		/* current character */
-	FILE 		*file;		/* source */
+get_number(int *numptr, int low, char *names[], int ch, FILE *file)
+	/* int	*numptr;	where does the result go? */
+	/* int	low;/		offset applied to result if symbolic enum used */
+	/* char	*names[];	symbolic names, if any, for enums */
+	/* int	ch;		current character */
+	/* FILE 		*file;		source */
 {
 	char	temp[MAX_TEMPSTR], *pc;
 	int	len, i, all_digits;
@@ -475,11 +475,11 @@ get_number(numptr, low, names, ch, file)
 
 
 static int
-set_element(bits, low, high, number)
-	bitstr_t	*bits; 		/* one bit per flag, default=FALSE */
-	int		low;
-	int		high;
-	int		number;
+set_element(bitstr_t *bits, int low, int high, int number)
+	/* bitstr_t	*bits; 		one bit per flag, default=FALSE */
+	/* int		low; */
+	/* int		high; */
+	/* int		number; */
 {
 	Debug(DPARS|DEXT, ("set_element(?,%d,%d,%d)\n", low, high, number))
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -33,8 +33,7 @@
 /* get_char(file) : like getc() but increment LineNumber on newlines
  */
 int
-get_char(file)
-	FILE	*file;
+get_char(FILE *file)
 {
 	int	ch;
 
@@ -74,9 +73,7 @@ get_char(file)
 /* unget_char(ch, file) : like ungetc but do LineNumber processing
  */
 void
-unget_char(ch, file)
-	int	ch;
-	FILE	*file;
+unget_char(int ch, FILE *file)
 {
 
 	/*
@@ -108,11 +105,7 @@ unget_char(ch, file)
  *		(4) returns EOF or terminating character, whichever
  */
 int
-get_string(string, size, file, terms)
-	char	*string;
-	int	size;
-	FILE	*file;
-	char	*terms;
+get_string(char *string, int size, FILE *file, char *terms)
 {
 	int	ch;
 
@@ -133,8 +126,7 @@ get_string(string, size, file, terms)
 /* skip_comments(file) : read past comment (if any)
  */
 void
-skip_comments(file)
-	FILE	*file;
+skip_comments(FILE *file)
 {
 	int	ch;
 


### PR DESCRIPTION
clang-15 with PG16 finally chokes on them.

```
20:30:42 /usr/bin/clang-15 -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -Xclang -no-opaque-pointers -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-uninitialized -Wno-implicit-fallthrough -Iinclude -I/usr/include/postgresql -I. -I./ -I/usr/include/postgresql/16/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -flto=thin -emit-llvm -c -o src/entry.bc src/entry.c
20:30:42 src/entry.c:243:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 get_list(bits, low, high, names, ch, file)
20:30:42 ^
20:30:42 src/entry.c:243:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 src/entry.c:290:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 get_range(bits, low, high, names, ch, file)
20:30:42 ^
20:30:42 src/entry.c:290:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 src/entry.c:393:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 get_number(numptr, low, names, ch, file)
20:30:42 ^
20:30:42 src/entry.c:393:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 src/entry.c:452:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 set_element(bits, low, high, number)
20:30:42 ^
20:30:42 src/entry.c:452:1: error: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
20:30:42 8 errors generated.
```

Close #277 