### PR TITLE
Restart pg_cron scheduler when terminating the background worker

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -665,7 +665,8 @@ PgCronLauncherMain(Datum arg)
 
 	ereport(LOG, (errmsg("pg_cron scheduler shutting down")));
 
-	proc_exit(0);
+	/* return error code to trigger restart */
+	proc_exit(1);
 }
 
 


### PR DESCRIPTION
I think the proc_exit(0) was done at an early stage to have a way of disabling the background worker in case it went haywire. By now pg_cron is quite battle-tested and can be mostly disabled using `cron.launch_active_jobs`, and users often accidentally kill the scheduler.

Fixes #188