### PR TITLE
Remove hard dependency on creation in the `pg_catalog` schema

### DIFF
--- a/pg_cron.control
+++ b/pg_cron.control
@@ -2,4 +2,3 @@ comment = 'Job scheduler for PostgreSQL'
 default_version = '1.6'
 module_pathname = '$libdir/pg_cron'
 relocatable = false
-schema = pg_catalog


### PR DESCRIPTION
Users were able to create the extension on any schema on versions earlier than 1.5. At version 1.5 we started to force users to create the extension in `pg_catalog`. This set of events cause hardship when doing a pg_dump&pg_restore.

Fixes: #274 