### PR TITLE
Qualify function call in migration script

### DIFF
--- a/pg_cron--1.2--1.3.sql
+++ b/pg_cron--1.2--1.3.sql
@@ -3,7 +3,7 @@
 CREATE SEQUENCE cron.runid_seq;
 CREATE TABLE cron.job_run_details (
 	jobid bigint,
-	runid bigint primary key default nextval('cron.runid_seq'),
+	runid bigint primary key default pg_catalog.nextval('cron.runid_seq'),
 	job_pid integer,
 	database text,
 	username text,


### PR DESCRIPTION
The migration script for pg_cron 1.2 to 1.3 was using nextval() without qualifying it with pg_catalog. This is a problem if the user has installed pg_cron in a schema other than pg_catalog. This commit fixes the problem by qualifying the function call.