### PR TITLE
Update the database when scheduling an existing job

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -253,7 +253,8 @@ ScheduleCronJob(text *scheduleText, text *commandText, text *databaseText,
 		appendStringInfo(&querybuf, "on conflict on constraint jobname_username_uniq ");
 		appendStringInfo(&querybuf, "do update set ");
 		appendStringInfo(&querybuf, "schedule = EXCLUDED.schedule, ");
-		appendStringInfo(&querybuf, "command = EXCLUDED.command");
+		appendStringInfo(&querybuf, "command = EXCLUDED.command, ");
+		appendStringInfo(&querybuf, "database = EXCLUDED.database");
 	}
 	else
 	{


### PR DESCRIPTION
When calling `cron.schedule_in_database` on an existing job, both the `schedule` and the `command` are updated to the new values, but not the `database`.

This PR adds the extra update statement so the `database` can also be updated.