### PR TITLE
Remove CacheInvalidateRelcacheByTuple and put CronJobCacheValid in shmem

### DIFF
--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -16,6 +16,7 @@
 #if (PG_VERSION_NUM < 120000)
 #include "datatype/timestamp.h"
 #endif
+#include "port/atomics.h"
 
 typedef enum
 {
@@ -45,7 +46,7 @@ typedef struct CronJob
 
 /* global settings */
 extern char *CronHost;
-extern bool CronJobCacheValid;
+extern pg_atomic_flag *CronJobCacheValid;
 extern bool EnableSuperuserJobs;
 
 

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -108,7 +108,7 @@ RefreshTaskHash(void)
 		task->secondsInterval = job->schedule.secondsInterval;
 	}
 
-	CronJobCacheValid = true;
+	pg_atomic_test_set_flag_impl(CronJobCacheValid);
 }
 
 


### PR DESCRIPTION
There is no need to call `CacheInvalidateRelcacheByTuple` when only updating the content of cron.job table( `CacheInvalidateRelcacheByTuple` should be called when the schema of crom.job udpated). Each time the `CacheInvalidateRelcacheByTuple` is called, the `Relaion` of pg_cron in launcher will be rebuilt which can lead some overhead.

Instead, put `CronJobCacheValid` into shmem, and set it to false in function InvalidateJobCache.