### PR TITLE
Make cron_unschedule_named() accept v1.4 SQL signature.

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -5,6 +5,10 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.0
 (1 row)
 
+-- Test binary compatibility with v1.4 function signature.
+ALTER EXTENSION pg_cron UPDATE TO '1.4';
+SELECT cron.unschedule(job_name := 'no_such_job');
+ERROR:  could not find valid entry for job 'no_such_job'
 ALTER EXTENSION pg_cron UPDATE;
 -- Vacuum every day at 10:00am (GMT)
 SELECT cron.schedule('0 10 * * *', 'VACUUM');

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -1,5 +1,8 @@
 CREATE EXTENSION pg_cron VERSION '1.0';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+-- Test binary compatibility with v1.4 function signature.
+ALTER EXTENSION pg_cron UPDATE TO '1.4';
+SELECT cron.unschedule(job_name := 'no_such_job');
 ALTER EXTENSION pg_cron UPDATE;
 
 -- Vacuum every day at 10:00am (GMT)


### PR DESCRIPTION
The PostgreSQL-recommended way to handle this would have been to introduce a new C symbol for the new signature.  It's too late for that, so use get_fn_expr_argtype() to discover the caller's expectations. Fixes https://github.com/citusdata/pg_cron/issues/267.