### PR TITLE
Fix compiler error on Illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ ifeq ($(CC),gcc)
 else
     PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 endif
+ifeq ($(shell uname -s),SunOS)
+    PG_CPPFLAGS += -D__EXTENSIONS__
+endif
 SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
     PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 endif
 ifeq ($(shell uname -s),SunOS)
-    PG_CPPFLAGS += -D__EXTENSIONS__
+    PG_CPPFLAGS += -Wno-sign-compare -D__EXTENSIONS__
 endif
 SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs


### PR DESCRIPTION
Hi,

When I try to use pg_cron on Illumos, there are some errors, such as following:

```
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -Wsign-compare -ggdb -O0 -ftree-vectorize -pipe -fexceptions -Wl,-rpath,/home/japin/postgres/build/pg/lib -fPIC -fvisibility=hidden -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I/home/japin/postgres/build/pg/include -I. -I./ -I/home/japin/postgres/build/pg/include/server -I/home/japin/postgres/build/pg/include/internal -I/opt/local/include  -D_POSIX_PTHREAD_SEMANTICS -I/opt/local/include/libxml2 -I/opt/local/include -I/opt/local/include -I/opt/local/include   -c -o src/entry.o src/entry.c -MMD -MP -MF .deps/entry.Po
In file included from /home/japin/postgres/build/pg/include/server/postgres.h:46,
                 from src/entry.c:26:
/home/japin/postgres/build/pg/include/server/utils/elog.h:429:20: error: unknown type name 'sigjmp_buf'
  429 | extern PGDLLIMPORT sigjmp_buf *PG_exception_stack;
      |                    ^~~~~~~~~~
src/entry.c: In function 'get_number':
src/entry.c:468:9: error: implicit declaration of function 'strcasecmp'; did you mean 'pg_strcasecmp'? [-Werror=implicit-function-declaration]
  468 |    if (!strcasecmp(names[i], temp)) {
      |         ^~~~~~~~~~
      |         pg_strcasecmp
cc1: all warnings being treated as errors
make: *** [/home/japin/postgres/build/pg/lib/pgxs/src/makefiles/../../src/Makefile.global:962: src/entry.o] Error 1
```