### PR TITLE
Add YugabyteDB to list of supported services

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ The following table keeps track of which of the major managed Postgres services 
 | [Scaleway](https://www.scaleway.com/en/database/) | :heavy_check_mark:  |
 | [Supabase](https://supabase.io/docs/guides/database) | :heavy_check_mark:  |
 | [Tembo](https://tembo.io) | :heavy_check_mark:  |
+| [YugabyteDB](https://www.yugabyte.com/) | :heavy_check_mark:  |
 
 
 ## Code of Conduct


### PR DESCRIPTION
YugabyteDB now fully supports the pg_cron extension.