### PR TITLE
Replace MemoryContextResetAndDeleteChildren macro with MemoryContextReset for PG 17 compatibility

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -141,7 +141,7 @@ InitializeJobMetadataCache(void)
 void
 ResetJobMetadataCache(void)
 {
-	MemoryContextResetAndDeleteChildren(CronJobContext);
+	MemoryContextReset(CronJobContext);
 
 	CronJobHash = CreateCronJobHash();
 }


### PR DESCRIPTION
Hi, Postgres 17 Beta 1 is out and I noticed pg_cron has a small compatibility issue with it. This commit should fix that. It assumes pg_cron is not interested in supporting PG versions before 9.5 based on what the README implies about supported versions being PG 10 and higher.

---
(The following is the commit message)

MemoryContextResetAndDeleteChildren will be retired in the upcoming PG 17 [0]. It has been equivalent to MemoryContextReset since PG 9.5 [1]. The reference to MemoryContextResetAndDeleteChildren is thus replaced by MemoryContextReset for compatibility purposes.

[0] https://github.com/postgres/postgres/commit/6a72c42fd5af7ada49584694f543eb0

[1] https://github.com/postgres/postgres/commit/eaa5808e8ec4e82ce1a87103a6b6f68