### PR TITLE
Do not cache CronJobRelationId in job unschedule functions

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -285,6 +285,35 @@ SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
 SELECT cron.schedule('bad-last-dom-job1', '0 11 $foo * *', 'VACUUM FULL');
 ERROR:  invalid schedule: 0 11 $foo * *
 HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
+-- unschedule across extension recreates
+SELECT cron.schedule('my-job1', '0 11 * * *', 'VACUUM');
+ schedule 
+----------
+        6
+(1 row)
+
+SELECT cron.unschedule('my-job1');
+ unschedule 
+------------
+ t
+(1 row)
+
+DROP EXTENSION pg_cron;
+CREATE EXTENSION pg_cron;
+SELECT cron.unschedule(1);
+ERROR:  could not find valid entry for job 1
+SELECT cron.schedule('my-job2', '* * * * *', 'VACUUM');
+ schedule 
+----------
+        1
+(1 row)
+
+SELECT cron.unschedule('my-job2');
+ unschedule 
+------------
+ t
+(1 row)
+
 -- cleaning
 DROP EXTENSION pg_cron;
 drop user pgcron_cront;

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -149,6 +149,15 @@ SELECT jobid, jobname, schedule, command FROM cron.job ORDER BY jobid;
 -- invalid last of day job
 SELECT cron.schedule('bad-last-dom-job1', '0 11 $foo * *', 'VACUUM FULL');
 
+-- unschedule across extension recreates
+SELECT cron.schedule('my-job1', '0 11 * * *', 'VACUUM');
+SELECT cron.unschedule('my-job1');
+DROP EXTENSION pg_cron;
+CREATE EXTENSION pg_cron;
+SELECT cron.unschedule(1);
+SELECT cron.schedule('my-job2', '* * * * *', 'VACUUM');
+SELECT cron.unschedule('my-job2');
+
 -- cleaning
 DROP EXTENSION pg_cron;
 drop user pgcron_cront;

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -642,6 +642,7 @@ cron_unschedule(PG_FUNCTION_ARGS)
 	cronSchemaId = get_namespace_oid(CRON_SCHEMA_NAME, false);
 	cronJobIndexId = get_relname_relid(JOB_ID_INDEX_NAME, cronSchemaId);
 
+	CachedCronJobRelationId = InvalidOid;
 	cronJobsTable = table_open(CronJobRelationId(), RowExclusiveLock);
 
 	ScanKeyInit(&scanKey[0], Anum_cron_job_jobid,
@@ -667,6 +668,7 @@ cron_unschedule(PG_FUNCTION_ARGS)
 
 	CommandCounterIncrement();
 	InvalidateJobCache();
+	CachedCronJobRelationId = InvalidOid;
 
 	PG_RETURN_BOOL(true);
 }
@@ -712,6 +714,7 @@ cron_unschedule_named(PG_FUNCTION_ARGS)
 		jobName = TextDatumGetCString(jobNameDatum);
 	}
 
+	CachedCronJobRelationId = InvalidOid;
 	cronJobsTable = table_open(CronJobRelationId(), RowExclusiveLock);
 
 	ScanKeyInit(&scanKey[0], Anum_cron_job_jobname,
@@ -738,6 +741,7 @@ cron_unschedule_named(PG_FUNCTION_ARGS)
 
 	CommandCounterIncrement();
 	InvalidateJobCache();
+	CachedCronJobRelationId = InvalidOid;
 
 	PG_RETURN_BOOL(true);
 }


### PR DESCRIPTION
`unschedule` and `unschedule_named` use `CronJobRelationId()` which caches the `CachedCronJobRelationId` on the backend of the user connection. This connection does not register for cache invalidations so this value is not cleared when the extension is dropped and recreated leading to errors.

This change fixes the issue adding `CronJobRelationIdUncached` function and using in places where we do not want to cache the value. 

Fixes #344