### PR TITLE
Fix bug with invalidation of CachedCronJobRelationId

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -9,6 +9,9 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT cron.unschedule(job_name := 'no_such_job');
 ERROR:  could not find valid entry for job 'no_such_job'
+-- Test cache invalidation
+DROP EXTENSION pg_cron;
+CREATE EXTENSION pg_cron VERSION '1.4';
 ALTER EXTENSION pg_cron UPDATE;
 -- Vacuum every day at 10:00am (GMT)
 SELECT cron.schedule('0 10 * * *', 'VACUUM');

--- a/include/job_metadata.h
+++ b/include/job_metadata.h
@@ -62,4 +62,6 @@ extern int64 NextRunId(void);
 extern void MarkPendingRunsAsFailed(void);
 extern char *GetCronStatus(CronStatus cronstatus);
 
+extern void InvalidateJobCacheCallback(Datum argument, Oid relationId);
+
 #endif

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -3,6 +3,11 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 -- Test binary compatibility with v1.4 function signature.
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT cron.unschedule(job_name := 'no_such_job');
+
+-- Test cache invalidation
+DROP EXTENSION pg_cron;
+CREATE EXTENSION pg_cron VERSION '1.4';
+
 ALTER EXTENSION pg_cron UPDATE;
 
 -- Vacuum every day at 10:00am (GMT)

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -79,7 +79,6 @@ static int64 ScheduleCronJob(text *scheduleText, text *commandText,
 								bool active, text *jobnameText);
 static Oid CronExtensionOwner(void);
 static void EnsureDeletePermission(Relation cronJobsTable, HeapTuple heapTuple);
-static void InvalidateJobCacheCallback(Datum argument, Oid relationId);
 static void InvalidateJobCache(void);
 static Oid CronJobRelationId(void);
 
@@ -121,9 +120,6 @@ bool EnableSuperuserJobs = true;
 void
 InitializeJobMetadataCache(void)
 {
-	/* watch for invalidation events */
-	CacheRegisterRelcacheCallback(InvalidateJobCacheCallback, (Datum) 0);
-
 	CronJobContext = AllocSetContextCreate(CurrentMemoryContext,
 											 "pg_cron job context",
 											 ALLOCSET_DEFAULT_MINSIZE,
@@ -820,7 +816,7 @@ InvalidateJobCache(void)
  * InvalidateJobCacheCallback invalidates the job cache in response to
  * an invalidation event.
  */
-static void
+void
 InvalidateJobCacheCallback(Datum argument, Oid relationId)
 {
 	if (relationId == CachedCronJobRelationId ||

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -208,6 +208,9 @@ _PG_init(void)
 								"configuration variable in postgresql.conf.")));
 	}
 
+	/* watch for invalidation events */
+	CacheRegisterRelcacheCallback(InvalidateJobCacheCallback, (Datum) 0);
+
 	DefineCustomStringVariable(
 		"cron.database_name",
 		gettext_noop("Database in which pg_cron metadata is kept."),


### PR DESCRIPTION
The callback was registered only for bgworker and as a result client backends were failing to unschedule jobs if the extension was droped and recreated in the same session:
```
CREATE EXTENSION pg_cron;
SELECT cron.schedule('0 10 * * *', 'VACUUM');
SELECT cron.unschedule(1);
DROP EXTENSION pg_cron;
CREATE EXTENSION pg_cron;
SELECT cron.schedule('0 10 * * *', 'VACUUM');
SELECT cron.unschedule(1);
ERROR:  could not open relation with OID 16388
```

Update, just found out that this issue is already discovered (#344) and there is a fix (#345) that takes different approach.