### PR TITLE
Select procedure based on argument type of cron_unschedule_named

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -9,6 +9,18 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT cron.unschedule(job_name := 'no_such_job');
 ERROR:  could not find valid entry for job 'no_such_job'
+SELECT cron.schedule('testjob', '* * * * *', 'SELECT 1');
+ schedule 
+----------
+        1
+(1 row)
+
+SELECT cron.unschedule('testjob');
+ unschedule 
+------------
+ t
+(1 row)
+
 -- Test cache invalidation
 DROP EXTENSION pg_cron;
 CREATE EXTENSION pg_cron VERSION '1.4';

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -3,6 +3,8 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
 -- Test binary compatibility with v1.4 function signature.
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT cron.unschedule(job_name := 'no_such_job');
+SELECT cron.schedule('testjob', '* * * * *', 'SELECT 1');
+SELECT cron.unschedule('testjob');
 
 -- Test cache invalidation
 DROP EXTENSION pg_cron;


### PR DESCRIPTION
The #299 PR took care of bacward compatibility of the function, but there is still one problem left. If extension isn't updated type of the jobname field in the cron.job table is still NAME, and as a result scan was failing to find rows and unschedule a named job.

This fix is relying on the fact that SQL API of the unschedule() function is updated consistently with the cron.job table definition.