### PR TITLE
Updated readme to show that Instaclustr now supports pg_cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The following table keeps track of which of the major managed Postgres services 
 | [Scaleway](https://www.scaleway.com/en/database/) | :heavy_check_mark:  |
 | [Supabase](https://supabase.io/docs/guides/database) | :heavy_check_mark:  |
 | [Tembo](https://tembo.io) | :heavy_check_mark:  |
+| [Instaclustr](https://instaclustr.com) | :heavy_check_mark:  |
 
 
 ## Code of Conduct


### PR DESCRIPTION
Hi there, 

Instaclustr now supports pg_cron natively on our platform. Would be great if the readme could reflect that?

Chris