### PR TITLE
Add break in CRON_TASK_WAITING switch case.

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -1321,6 +1321,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 										cronJob->database,
 										cronJob->userName,
 										cronJob->command, GetCronStatus(CRON_STATUS_STARTING));
+			break;
 		}
 
 		case CRON_TASK_START:


### PR DESCRIPTION
Otherwise, higher versions of GCC will throw errors due to '-Werror=implicit-fallthrough'.