### PR TITLE
Fix maybe-uninitialized compile warn.

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -442,6 +442,8 @@ get_number(int *numptr, int low, char *names[], int ch, FILE *file)
 	 */
 	pc = temp;
 	len = 0;
+	/* keep compiler quiet */
+	*numptr = 0;
 	all_digits = TRUE;
 	while (isalnum(ch)) {
 		if (++len >= MAX_TEMPSTR)


### PR DESCRIPTION
Hi! Im getting an compiler errors, which are surely false-positive, but lets get compiler quiet?

```
cc1: all warnings being treated as errors
make: *** [/usr/local/cbdb/lib/postgresql/pgxs/src/makefiles/../../src/Makefile.global:1031: src/pg_cron.o] Error 1 make: *** Waiting for unfinished jobs....
In function ‘get_range’,
    inlined from ‘get_list’ at src/entry.c:308:8,
    inlined from ‘parse_cron_entry’ at src/entry.c:195:8:
src/entry.c:413:26: error: ‘num3’ may be used uninitialized [-Werror=maybe-uninitialized]
  412 |         if (num1 < low || num1 > high || num2 < low || num2 > high ||
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  413 |                 num3 < 0 || num3 > high)
      |                 ~~~~~~~~~^~~~~~~~~~~~~~
src/entry.c: In function ‘parse_cron_entry’:
src/entry.c:337:37: note: ‘num3’ was declared here
  337 |         auto int        num1, num2, num3;
      |                                     ^~~~
cc1: all warnings being treated as errors
```



some info about system i use

```
reshke@yezzey-cbdb:~/cloudberrydb/contrib/pg_cron$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04 LTS
Release:	24.04
Codename:	noble
reshke@yezzey-cbdb:~/cloudberrydb/contrib/pg_cron$ gcc --version
gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


```

