### PR TITLE
Introduce cron_shutdown function for stopping the main background worker

### DIFF
--- a/pg_cron--1.6--1.7.sql
+++ b/pg_cron--1.6--1.7.sql
@@ -1,0 +1,17 @@
+DROP FUNCTION IF EXISTS cron.shutdown();
+CREATE FUNCTION cron.shutdown()
+    RETURNS bool
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$cron_shutdown$$;
+COMMENT ON FUNCTION cron.shutdown()
+    IS 'shutdown pg_cron';
+REVOKE ALL ON FUNCTION cron.shutdown() FROM PUBLIC;
+
+DROP FUNCTION IF EXISTS cron.startup();
+CREATE FUNCTION cron.startup()
+    RETURNS bool
+    LANGUAGE C STRICT
+    AS 'MODULE_PATHNAME', $$cron_startup$$;
+COMMENT ON FUNCTION cron.startup()
+    IS 'starts up pg_cron after it was shut down';
+REVOKE ALL ON FUNCTION cron.startup() FROM PUBLIC;


### PR DESCRIPTION
Normally the main background worker used to start tasks cannot be stopped, because it always auto restarts.

This change introduces SQL function `cron_shutdown` that can be used to stop the background worker.

It works by creating a shared memory that holds pid of the main background worker and bool flag specifying whether to restart the worker. By default, this keeps the current behaviour of automatically restarting the worker whenever it's killed. In situations when the user actually wants the main worker to be killed, It gives a way to do it.

This currently doesn't stop any other worker started by the scheduler.

The change that introduced auto-restarts is https://github.com/citusdata/pg_cron/pull/286

Fixes https://github.com/citusdata/pg_cron/issues/352