### PR TITLE
Update PortalDefineQuery call for postgres 18 compatibility

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -2265,7 +2265,11 @@ ExecuteSqlString(const char *sql)
 		portal = CreatePortal("", true, true);
 		/* Don't display the portal in pg_cursors */
 		portal->visible = false;
-		PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
+		#if PG_VERSION_NUM < 180000
+			PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
+		#else
+			PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL, NULL);
+		#endif
 		PortalStart(portal, NULL, 0, InvalidSnapshot);
 		PortalSetResultFormat(portal, 1, &format);		/* binary format */
 


### PR DESCRIPTION
I was trying to build pg_cron against the current postgres master and noticed this blip.

commit message follows
`
525392d from postgres upstream adds a new argument in PortalDefineQuery, CachedPlanSource. The CachedPlan in this call is NULL so naturally CachedPlanSource is passed NULL here.
`
