### PR TITLE
Grant ownership of schema cron and few functions to the user who creates the extension

### DIFF
--- a/pg_cron--1.5--1.6.sql
+++ b/pg_cron--1.5--1.6.sql
@@ -1,1 +1,44 @@
 /* no SQL changes in 1.6 */
+
+/* Ensure the extension can be installed as trusted extension by non-superuser*/
+DO $$
+DECLARE
+    pg_version_num TEXT;
+    major_version INT;
+BEGIN
+    -- Get the pg version
+    SELECT current_setting('server_version_num') INTO pg_version_num;
+    major_version := pg_version_num::INT;
+
+    -- Starting from pg13, if the extension script contains the string @extowner@, 
+    -- that string is replaced with the (suitably quoted) name of the user calling 
+    -- CREATE EXTENSION or ALTER EXTENSION.
+    IF major_version >= 130000 THEN
+        ALTER SCHEMA cron OWNER TO @extowner@;
+
+        -- make extension-owner as the owner of the tables
+        ALTER TABLE cron.job OWNER TO @extowner@;
+        ALTER TABLE cron.job_run_details OWNER TO @extowner@;
+
+        -- extension-owner should be able to read and write to the tables
+        GRANT ALL ON ALL TABLES IN SCHEMA cron TO @extowner@;
+        GRANT ALL ON ALL SEQUENCES IN SCHEMA cron TO @extowner@;
+
+        -- extension-owner should own the basic functions which are safe.
+        -- schedule_in_database is removed from this list, 
+        -- as SUPERUSER can grant access to it explicitly if needed.
+        GRANT ALL ON FUNCTION cron.alter_job(bigint,text,text,text,text,boolean) TO @extowner@;
+        GRANT ALL ON FUNCTION cron.job_cache_invalidate() TO @extowner@;
+        GRANT ALL ON FUNCTION cron.schedule(text,text) TO @extowner@;
+        GRANT ALL ON FUNCTION cron.schedule(text,text,text) TO @extowner@;
+        GRANT ALL ON FUNCTION cron.unschedule(bigint) TO @extowner@;
+        GRANT ALL ON FUNCTION cron.unschedule(text) TO @extowner@;
+
+        ALTER FUNCTION cron.alter_job(bigint,text,text,text,text,boolean) OWNER TO @extowner@;
+        ALTER FUNCTION cron.job_cache_invalidate() OWNER TO @extowner@;
+        ALTER FUNCTION cron.schedule(text,text) OWNER TO @extowner@;
+        ALTER FUNCTION cron.schedule(text,text,text) OWNER TO @extowner@;
+        ALTER FUNCTION cron.unschedule(bigint) OWNER TO @extowner@;
+        ALTER FUNCTION cron.unschedule(text) OWNER TO @extowner@;
+    END IF;
+END $$;


### PR DESCRIPTION
## Context

If PostgreSQL admin allows `pg_cron` to be trusted extension (by not granting superuser access to the users), then users should be ale to install and run pg_cron on their databases without the intervention of superusers/DBAs.

But today, when we make `pg_cron` as a trusted extension, superuser has to grant privileges to the extension owners to use schema `cron` and the functions in it, to schedule and unscheduled jobs.

As extensions can use `@extowner@` in the extension's SQL starting from Postgresql 13, we can use it to make user experience better, by granting sufficient privileges to the extension owner (as only users with CREATE privilege can create extension in database).

This patch should NOT affect PostgreSQL versions below 13.