### PR TITLE
Revert "Update PortalDefineQuery call for postgres 18 compatibility"

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -2265,11 +2265,7 @@ ExecuteSqlString(const char *sql)
 		portal = CreatePortal("", true, true);
 		/* Don't display the portal in pg_cursors */
 		portal->visible = false;
-		#if PG_VERSION_NUM < 180000
-			PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
-		#else
-			PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL, NULL);
-		#endif
+		PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
 		PortalStart(portal, NULL, 0, InvalidSnapshot);
 		PortalSetResultFormat(portal, 1, &format);		/* binary format */
 


### PR DESCRIPTION
Reverts citusdata/pg_cron#387

Seems like this was reverted https://github.com/postgres/postgres/commit/1722d5eb0 upstream, so we should revert that here too.