### PR TITLE
Some fix to build on FreeBSD 14.3 and PostgreSQL 18 beta 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 ifeq ($(CC),gcc)
     PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-uninitialized -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 else
-    PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
+    PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-missing-variable-declarations -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 endif
 ifeq ($(shell uname -s),SunOS)
     PG_CPPFLAGS += -Wno-sign-compare -D__EXTENSIONS__

--- a/include/cron.h
+++ b/include/cron.h
@@ -236,24 +236,24 @@ entry * parse_cron_entry(char *);
 
 #ifdef MAIN_PROGRAM
 # if !defined(LINT) && !defined(lint)
-char	*copyright[] = {
+static char	*copyright[] = {
 		"@(#) Copyright 1988,1989,1990,1993,1994 by Paul Vixie",
 		"@(#) All rights reserved"
 	};
 # endif
 
-char	*MonthNames[] = {
+static char	*MonthNames[] = {
 		"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 		NULL
 	};
 
-char	*DowNames[] = {
+static char	*DowNames[] = {
 		"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
 		NULL
 	};
 
-char	*ecodes[] = {
+static char	*ecodes[] = {
 		"no error",
 		"bad minute",
 		"bad hour",
@@ -268,11 +268,11 @@ char	*ecodes[] = {
 	};
 
 
-char	*ProgramName;
-int	LineNumber;
-time_t	StartTime;
-time_min virtualTime;
-time_min clockTime;
+static char	*ProgramName;
+static int	LineNumber;
+static time_t	StartTime;
+static time_min virtualTime;
+static time_min clockTime;
 
 # if DEBUGGING
 int	DebugFlags;

--- a/include/cron.h
+++ b/include/cron.h
@@ -236,24 +236,24 @@ entry * parse_cron_entry(char *);
 
 #ifdef MAIN_PROGRAM
 # if !defined(LINT) && !defined(lint)
-static char	*copyright[] = {
+char	*copyright[] = {
 		"@(#) Copyright 1988,1989,1990,1993,1994 by Paul Vixie",
 		"@(#) All rights reserved"
 	};
 # endif
 
-static char	*MonthNames[] = {
+char	*MonthNames[] = {
 		"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 		NULL
 	};
 
-static char	*DowNames[] = {
+char	*DowNames[] = {
 		"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
 		NULL
 	};
 
-static char	*ecodes[] = {
+char	*ecodes[] = {
 		"no error",
 		"bad minute",
 		"bad hour",
@@ -268,11 +268,11 @@ static char	*ecodes[] = {
 	};
 
 
-static char	*ProgramName;
-static int	LineNumber;
-static time_t	StartTime;
-static time_min virtualTime;
-static time_min clockTime;
+char	*ProgramName;
+int	LineNumber;
+time_t	StartTime;
+time_min virtualTime;
+time_min clockTime;
 
 # if DEBUGGING
 int	DebugFlags;

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -120,7 +120,7 @@ typedef enum
 /* forward declarations */
 void _PG_init(void);
 void _PG_fini(void);
-static void pg_cron_sigterm(SIGNAL_ARGS);
+static  void pg_cron_sigterm(SIGNAL_ARGS);
 static void pg_cron_sighup(SIGNAL_ARGS);
 PGDLLEXPORT void PgCronLauncherMain(Datum arg);
 PGDLLEXPORT void CronBackgroundWorker(Datum arg);
@@ -168,7 +168,7 @@ static int MaxRunningTasks = 0;
 static int CronLogMinMessages = WARNING;
 static bool UseBackgroundWorkers = false;
 
-static char  *cron_timezone = NULL;
+char  *cron_timezone = NULL;
 
 static const struct config_enum_entry cron_message_level_options[] = {
 	{"debug5", DEBUG5, false},

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -168,7 +168,7 @@ static int MaxRunningTasks = 0;
 static int CronLogMinMessages = WARNING;
 static bool UseBackgroundWorkers = false;
 
-char  *cron_timezone = NULL;
+static char  *cron_timezone = NULL;
 
 static const struct config_enum_entry cron_message_level_options[] = {
 	{"debug5", DEBUG5, false},
@@ -2265,7 +2265,11 @@ ExecuteSqlString(const char *sql)
 		portal = CreatePortal("", true, true);
 		/* Don't display the portal in pg_cursors */
 		portal->visible = false;
-		PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
+		#if PG_VERSION_NUM < 180000
+						PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
+		#else
+						PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL, NULL);
+		#endif
 		PortalStart(portal, NULL, 0, InvalidSnapshot);
 		PortalSetResultFormat(portal, 1, &format);		/* binary format */
 


### PR DESCRIPTION
1. declaring static variabile in some files;
2. restrored old #392 commit. Building on FreeBS 14.3 and PostgreSQL 18 I have:
```
src/pg_cron.c:2268:71: error: too few arguments to function call, expected 7, have 6
 2268 |                 PortalDefineQuery(portal, NULL, sql, commandTag, plantree_list, NULL);
      |                 ~~~~~~~~~~~~~~~~~                                                   ^
/usr/local/include/postgresql/server/utils/portal.h:239:13: note: 'PortalDefineQuery' declared here
  239 | extern void PortalDefineQuery(Portal portal,
      |             ^                 ~~~~~~~~~~~~~~
  240 |                                                           const char *prepStmtName,
      |                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~
  241 |                                                           const char *sourceText,
      |                                                           ~~~~~~~~~~~~~~~~~~~~~~~
  242 |                                                           CommandTag commandTag,
      |                                                           ~~~~~~~~~~~~~~~~~~~~~~
  243 |                                                           List *stmts,
      |                                                           ~~~~~~~~~~~~
  244 |                                                           CachedPlan *cplan,
      |                                                           ~~~~~~~~~~~~~~~~~~
  245 |                                                           CachedPlanSource *plansource);
      |                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```