### PR TITLE
Fix type mismatch in dsm_attach() argument by using DatumGetUInt32()

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -2074,7 +2074,7 @@ CronBackgroundWorker(Datum main_arg)
 												 ALLOCSET_DEFAULT_MAXSIZE);
 
 	/* Set up a dynamic shared memory segment. */
-	seg = dsm_attach(DatumGetInt32(main_arg));
+	seg = dsm_attach(DatumGetUInt32(main_arg));
 	if (seg == NULL)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),


### PR DESCRIPTION
The argument passed to dsm_attach() represents a dynamic shared memory segment handle, which is defined as a uint32. The existing code incorrectly used DatumGetInt32(), which may lead to unexpected behavior if the value exceeds the range of a signed 32-bit integer.