### PR TITLE
Remove unnecessary cron cruft that errors on modern gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ OBJS = $(patsubst %.c,%.o,$(wildcard src/*.c))
 ifeq ($(CC),gcc)
     PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-uninitialized -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 else
-    PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-missing-variable-declarations -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
+    PG_CPPFLAGS = -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-implicit-fallthrough -Iinclude -I$(libpq_srcdir)
 endif
 ifeq ($(shell uname -s),SunOS)
     PG_CPPFLAGS += -Wno-sign-compare -D__EXTENSIONS__

--- a/include/cron.h
+++ b/include/cron.h
@@ -234,64 +234,6 @@ entry * parse_cron_entry(char *);
 				 * extern them elsewhere.
 				 */
 
-#ifdef MAIN_PROGRAM
-# if !defined(LINT) && !defined(lint)
-char	*copyright[] = {
-		"@(#) Copyright 1988,1989,1990,1993,1994 by Paul Vixie",
-		"@(#) All rights reserved"
-	};
-# endif
-
-char	*MonthNames[] = {
-		"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-		NULL
-	};
-
-char	*DowNames[] = {
-		"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
-		NULL
-	};
-
-char	*ecodes[] = {
-		"no error",
-		"bad minute",
-		"bad hour",
-		"bad day-of-month",
-		"bad month",
-		"bad day-of-week",
-		"bad command",
-		"bad time specifier",
-		"bad username",
-		"command too long",
-		NULL
-	};
-
-
-char	*ProgramName;
-int	LineNumber;
-time_t	StartTime;
-time_min virtualTime;
-time_min clockTime;
-
-# if DEBUGGING
-int	DebugFlags;
-char	*DebugFlagNames[] = {	/* sync with #defines */
-		"ext", "sch", "proc", "pars", "load", "misc", "test", "bit",
-		NULL		/* NULL must be last element */
-	};
-# endif /* DEBUGGING */
-#else /*MAIN_PROGRAM*/
-extern	char	*copyright[],
-		*MonthNames[],
-		*DowNames[],
-		*ProgramName;
+extern	char *MonthNames[];
+extern	char *DowNames[];
 extern	int	LineNumber;
-extern	time_t	StartTime;
-extern  time_min virtualTime;
-extern  time_min clockTime;
-# if DEBUGGING
-extern	int	DebugFlags;
-extern	char	*DebugFlagNames[];
-# endif /* DEBUGGING */
-#endif /*MAIN_PROGRAM*/

--- a/src/entry.c
+++ b/src/entry.c
@@ -30,6 +30,40 @@
 #include "cron.h"
 
 
+char	*MonthNames[] = {
+		"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+		"Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+		NULL
+	};
+
+char	*DowNames[] = {
+		"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
+		NULL
+	};
+
+char	*ecodes[] = {
+		"no error",
+		"bad minute",
+		"bad hour",
+		"bad day-of-month",
+		"bad month",
+		"bad day-of-week",
+		"bad command",
+		"bad time specifier",
+		"bad username",
+		"command too long",
+		NULL
+	};
+
+
+# if DEBUGGING
+int	DebugFlags;
+char	*DebugFlagNames[] = {	/* sync with #defines */
+		"ext", "sch", "proc", "pars", "load", "misc", "test", "bit",
+		NULL		/* NULL must be last element */
+	};
+# endif /* DEBUGGING */
+
 typedef	enum ecode {
 	e_none, e_minute, e_hour, e_dom, e_month, e_dow,
 	e_cmd, e_timespec, e_username, e_cmd_len

--- a/src/misc.c
+++ b/src/misc.c
@@ -29,6 +29,8 @@
 #include <string.h>
 #include "cron.h"
 
+int	LineNumber;
+
 
 /* get_char(file) : like getc() but increment LineNumber on newlines
  */


### PR DESCRIPTION
Some versions of GCC are now (quite reasonably) tripping over some of the old Vixie cron declarations.

Fixes #396