### PR TITLE
Invalidate job cache in case of `relationId == InvalidOid`

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -821,6 +821,7 @@ void
 InvalidateJobCacheCallback(Datum argument, Oid relationId)
 {
 	if (relationId == CachedCronJobRelationId ||
+		relationId == InvalidOid ||
 		CachedCronJobRelationId == InvalidOid)
 	{
 		CronJobCacheValid = false;


### PR DESCRIPTION
There are might be cases when `InvalidOid` is passed to `InvalidateJobCacheCallback()` as `relationId`. In this case it is necessary to invalidate entire cache.

In some cases we see a bug when `pg_cron` continues to execute a job which was unscheduled by `cron.unschedule()`. Unfortunately I cannot reproduce this reliably. I suspect that the issue might be in `InvalidateJobCacheCallback()` which doesn't handle the case when `relationId == InvalidOid`.

`pg_cron` version `1.6.4`.