### PR TITLE
use PG_MODULE_MAGIC_EXT to report the full version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ endif
 ifeq ($(shell uname -s),SunOS)
     PG_CPPFLAGS += -Wno-sign-compare -D__EXTENSIONS__
 endif
+PG_CPPFLAGS += -DPG_CRON_VERSION=$(shell sed -r -n -e '1s/.* v([^ ]*) .*/\1/p' <CHANGELOG.md)
 SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -94,7 +94,11 @@
 #include "utils/builtins.h"
 
 
+#ifdef PG_MODULE_MAGIC_EXT
+PG_MODULE_MAGIC_EXT(.name = "pg_cron", .version = "1.6.7");
+#else
 PG_MODULE_MAGIC;
+#endif
 
 #ifndef MAXINT8LEN
 #define MAXINT8LEN 20

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -95,7 +95,7 @@
 
 
 #ifdef PG_MODULE_MAGIC_EXT
-PG_MODULE_MAGIC_EXT(.name = "pg_cron", .version = "1.6.7");
+PG_MODULE_MAGIC_EXT(.name = "pg_cron", .version = PG_CRON_VERSION);
 #else
 PG_MODULE_MAGIC;
 #endif


### PR DESCRIPTION
On PG 18+, PG_MODULE_MAGIC_EXT allows the module to report its name and version, where the version can be more fine-grained than the SQL-level extension.

So for an extension installed on a coarser version 1.6:

postgres=# select extname, extversion from pg_extension where extname = 'pg_cron';
 extname | extversion
---------+------------
 pg_cron | 1.6
(1 row)

This change allows the loaded modules to report, not only this...

postgres=# select pg_get_loaded_modules();
 pg_get_loaded_modules
-----------------------
 (,,pg_cron.so)
(1 row)

...but also the bugfix release:

postgres=# select pg_get_loaded_modules();
   pg_get_loaded_modules
----------------------------
 (pg_cron,1.6.7,pg_cron.so)
(1 row)

This change can help troubleshoot cases where the release is relevant and consulting the OS packages is more difficult, or where the .so might have changed without a database server restart.

It does add a small amount of extra work for releases, in the sense that pg_cron.c now has to be updated along with the changelog for every release henceforth.