### PR TITLE
Make cron_schedule_named() accept v1.3 SQL signature.

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -5,6 +5,20 @@ SELECT extversion FROM pg_extension WHERE extname='pg_cron';
  1.0
 (1 row)
 
+-- Test binary compatibility with v1.3 function signature.
+ALTER EXTENSION pg_cron UPDATE TO '1.3';
+SELECT cron.schedule('test', '* * * * *', 'SELECT 1');
+ schedule 
+----------
+        1
+(1 row)
+
+SELECT cron.unschedule('test');
+ unschedule 
+------------
+ t
+(1 row)
+
 -- Test binary compatibility with v1.4 function signature.
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT cron.unschedule(job_name := 'no_such_job');
@@ -12,7 +26,7 @@ ERROR:  could not find valid entry for job 'no_such_job'
 SELECT cron.schedule('testjob', '* * * * *', 'SELECT 1');
  schedule 
 ----------
-        1
+        2
 (1 row)
 
 SELECT cron.unschedule('testjob');

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -1,5 +1,9 @@
 CREATE EXTENSION pg_cron VERSION '1.0';
 SELECT extversion FROM pg_extension WHERE extname='pg_cron';
+-- Test binary compatibility with v1.3 function signature.
+ALTER EXTENSION pg_cron UPDATE TO '1.3';
+SELECT cron.schedule('test', '* * * * *', 'SELECT 1');
+SELECT cron.unschedule('test');
 -- Test binary compatibility with v1.4 function signature.
 ALTER EXTENSION pg_cron UPDATE TO '1.4';
 SELECT cron.unschedule(job_name := 'no_such_job');

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -491,6 +491,12 @@ cron_schedule_named(PG_FUNCTION_ARGS)
 
 	if (PG_ARGISNULL(0))
 		ereport(ERROR, (errmsg("job_name can not be NULL")));
+	/*
+	* v1.4 changed the first argument type from "name" to "text". Cope with
+	* calls from "CREATE EXTENSION pg_cron VERSION '1.3'".
+	*/
+	else if (get_fn_expr_argtype(fcinfo->flinfo, 0) == NAMEOID)
+		jobnameText = cstring_to_text(NameStr(*PG_GETARG_NAME(0)));
 	else
 		jobnameText = PG_GETARG_TEXT_P(0);
 


### PR DESCRIPTION
Use a trick similar to #299.

Without the fix postgres crashes:
```sql
postgres=# create extension pg_cron version "1.3";
CREATE EXTENSION
postgres=# select cron.schedule('test', '* * * * *', 'select 1');
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
The connection to the server was lost. Attempting reset: Failed.
!?>
```

Crash stack trace:
```
(gdb) bt
#0  __memmove_avx_unaligned_erms () at ../sysdeps/x86_64/multiarch/memmove-vec-unaligned-erms.S:872
#1  0x00005637d94d45a8 in memcpy (__len=488429913, __src=<optimized out>, __dest=0x7f5506a32048) at /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29
#2  text_to_cstring (t=t@entry=0x56380afa9598) at varlena.c:233
#3  0x00007f552d426443 in ScheduleCronJob (scheduleText=scheduleText@entry=0x56380afa92a8, commandText=commandText@entry=0x56380afa94d8, databaseText=databaseText@entry=0x0, usernameText=0x0, active=<optimized out>, jobnameText=jobnameText@entry=0x56380afa9598)
    at src/job_metadata.c:334
#4  0x00007f552d427d3b in cron_schedule_named (fcinfo=0x56380afdf558) at src/job_metadata.c:523
#5  0x00005637d91648ea in ExecInterpExpr (state=0x56380afdf400, econtext=0x56380afdf0a8, isnull=0x0) at execExprInterp.c:953
#6  0x00005637d915fad9 in ExecInterpExprStillValid (state=0x56380afdf400, econtext=0x56380afdf0a8, isNull=0x0) at execExprInterp.c:2299
#7  0x00005637d91a828b in ExecEvalExprNoReturn (econtext=0x56380afdf0a8, state=0x56380afdf400) at ../../../src/include/executor/executor.h:419
#8  ExecEvalExprNoReturnSwitchContext (econtext=0x56380afdf0a8, state=0x56380afdf400) at ../../../src/include/executor/executor.h:460
#9  ExecProject (projInfo=0x56380afdf3f8) at ../../../src/include/executor/executor.h:492
#10 ExecResult (pstate=<optimized out>) at nodeResult.c:135
#11 0x00005637d9172f16 in ExecProcNodeFirst (node=0x56380afdef98) at execProcnode.c:469
#12 0x00005637d916a2f9 in ExecProcNode (node=0x56380afdef98) at ../../../src/include/executor/executor.h:315
#13 ExecutePlan (queryDesc=queryDesc@entry=0x56380af29de0, operation=operation@entry=CMD_SELECT, sendTuples=sendTuples@entry=true, numberTuples=numberTuples@entry=0, direction=direction@entry=ForwardScanDirection, dest=dest@entry=0x56380afe8cc0) at execMain.c:1707
#14 0x00005637d916a5f6 in standard_ExecutorRun (queryDesc=0x56380af29de0, direction=ForwardScanDirection, count=0) at execMain.c:366
#15 0x00005637d916a630 in ExecutorRun (queryDesc=queryDesc@entry=0x56380af29de0, direction=direction@entry=ForwardScanDirection, count=count@entry=0) at execMain.c:303
#16 0x00005637d9395c12 in PortalRunSelect (portal=portal@entry=0x56380b035ae0, forward=forward@entry=true, count=0, count@entry=9223372036854775807, dest=dest@entry=0x56380afe8cc0) at pquery.c:921
#17 0x00005637d9397629 in PortalRun (portal=portal@entry=0x56380b035ae0, count=count@entry=9223372036854775807, isTopLevel=isTopLevel@entry=true, dest=dest@entry=0x56380afe8cc0, altdest=altdest@entry=0x56380afe8cc0, qc=qc@entry=0x7ffe2b3ff970) at pquery.c:765
#18 0x00005637d93930b9 in exec_simple_query (query_string=query_string@entry=0x56380afa7ba0 "select cron.schedule('test', '* * * * *', 'select 1');") at postgres.c:1273
#19 0x00005637d939550a in PostgresMain (dbname=<optimized out>, username=<optimized out>) at postgres.c:4766
#20 0x00005637d938e211 in BackendMain (startup_data=<optimized out>, startup_data_len=<optimized out>) at backend_startup.c:124
#21 0x00005637d92caa4b in postmaster_child_launch (child_type=B_BACKEND, child_slot=1, startup_data=startup_data@entry=0x7ffe2b3ffbc0, startup_data_len=startup_data_len@entry=24, client_sock=client_sock@entry=0x7ffe2b3ffc10) at launch_backend.c:290
#22 0x00005637d92cd658 in BackendStartup (client_sock=client_sock@entry=0x7ffe2b3ffc10) at postmaster.c:3587
#23 0x00005637d92cf90c in ServerLoop () at postmaster.c:1702
#24 0x00005637d92d0dfb in PostmasterMain (argc=argc@entry=6, argv=argv@entry=0x56380af0f310) at postmaster.c:1400
#25 0x00005637d91d6c06 in main (argc=6, argv=0x56380af0f310) at main.c:227
```