### PR TITLE
Fix shm_mq_handle memory leak in launcher process

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -152,6 +152,7 @@ static bool jobCanceled(CronTask *task);
 static bool jobStartupTimeout(CronTask *task, TimestampTz currentTime);
 static char* pg_cron_cmdTuples(char *msg);
 static void bgw_generate_returned_message(StringInfoData *display_msg, ErrorData edata);
+static void CleanupCronTask(CronTask *task);
 
 /* global settings */
 char *CronTableDatabaseName = "postgres";
@@ -1481,8 +1482,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 
 			if (!registered)
 			{
-				dsm_detach(task->seg);
-				task->seg = NULL;
+				CleanupCronTask(task);
 				task->state = CRON_TASK_ERROR;
 				task->errorMessage = "could not start background process; more "
 									 "details may be available in the server log";
@@ -1498,8 +1498,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			status = WaitForBackgroundWorkerStartup(&task->handle, &pid);
 			if (status != BGWH_STARTED && status != BGWH_STOPPED)
 			{
-				dsm_detach(task->seg);
-				task->seg = NULL;
+				CleanupCronTask(task);
 				task->state = CRON_TASK_ERROR;
 				task->errorMessage = "could not start background process; more "
 									 "details may be available in the server log";
@@ -1697,8 +1696,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			{
 				TerminateBackgroundWorker(&task->handle);
 				WaitForBackgroundWorkerShutdown(&task->handle);
-				dsm_detach(task->seg);
-				task->seg = NULL;
+				CleanupCronTask(task);
 
 				break;
 			}
@@ -1720,9 +1718,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 
 				task->state = CRON_TASK_DONE;
 
-				dsm_detach(task->seg);
-
-				task->seg = NULL;
+				CleanupCronTask(task);
 				RunningTaskCount--;
 			}
 
@@ -1796,6 +1792,25 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			 */
 			task->pendingRunCount = currentPendingRunCount;
 		}
+	}
+}
+
+static void
+CleanupCronTask(CronTask *task)
+{
+	if (task == NULL)
+		return;
+
+	if (task->sharedMemoryQueue != NULL)
+	{
+		shm_mq_detach(task->sharedMemoryQueue);
+		task->sharedMemoryQueue = NULL;
+	}
+
+	if (task->seg != NULL)
+	{
+		dsm_detach(task->seg);
+		task->seg = NULL;
 	}
 }
 

--- a/src/task_states.c
+++ b/src/task_states.c
@@ -156,6 +156,8 @@ InitializeCronTask(CronTask *task, int64 jobId)
 	task->isActive = true;
 	task->errorMessage = NULL;
 	task->freeErrorMessage = false;
+	task->seg = NULL;
+	task->sharedMemoryQueue = NULL;
 }
 
 


### PR DESCRIPTION
When `cron.use_background_workers` is on, `shm_mq_attach()` allocates a `shm_mq_handle` in `TopMemoryContext` per job invocation. This handle was never freed, causing a small but unbounded palloc leak.

Introduce `CleanupCronTask()` which calls `shm_mq_detach()` and then `dsm_detach()`.

Also, in `InitializeCronTask()`, set `sharedMemoryQueue` and `seg` to NULL to ensure the NULL guard in `CleanupCronTask()` is reliable.

Each job invocation leaks a small amount of memory in the launcher process. When there are many frequently-scheduled jobs and a server that runs for a long time, this can amount to GBs of launcher process memory.

## Test

### Server

* Postgres 18.1 (Docker image `postgres:18-trixie`)
* pg_cron compiled from source (branch `main` commit 4d92ad7453ae, and this PR)

### postgres.conf settings

Turning off job logging to `job_run_details` and to the server log (because we're launching 50 jobs per second).

  ```
  shared_preload_libraries = 'pg_cron'
  cron.database_name = 'postgres'
  cron.log_run = off
  cron.log_statement = off
  cron.use_background_workers = on
  ```

### Test statements

Create 50 simple jobs that launch every second.

```sql
CREATE EXTENSION pg_cron;

DO $$
  BEGIN
    FOR i IN 1..50 LOOP
      PERFORM cron.schedule(format('job_%s', i), '1 second', format('select %s', i));
    END LOOP;
  END;
$$;
```

### Monitoring commands

Print launcher process size every 10 seconds:

```sh
#!/bin/bash
launcher_pid=$(pgrep -f "pg_cron launcher")
while true ; do
  now=$(date +%s)
  sleep $((10 - now % 10))
  echo "$(date),PID $launcher_pid,$(cat /proc/$launcher_pid/status | grep ^VmRSS)"
done
```

Print the launcher backend memory contexts:

```sh
#!/bin/bash
psql postgres://postgres:postgres@localhost:5432/postgres -c "SELECT pg_log_backend_memory_contexts(pid) FROM pg_stat_activity WHERE backend_type = 'pg_cron launcher'"
docker logs pg-cron-container | grep -E 'TopMemoryContext|Grand' | tail -2
```

## Results

### Branch main commit 4d92ad7453ae

VmRSS of the pg_cron launcher process grows from 17 MB to 43 MB over one hour.

```
Mon Mar  2 05:09:07 PM UTC 2026,PID 77,VmRSS:	   17492 kB
Mon Mar  2 05:14:07 PM UTC 2026,PID 77,VmRSS:	   19848 kB
Mon Mar  2 05:19:10 PM UTC 2026,PID 77,VmRSS:	   21992 kB
Mon Mar  2 05:20:20 PM UTC 2026,PID 77,VmRSS:	   23464 kB
Mon Mar  2 05:24:10 PM UTC 2026,PID 77,VmRSS:	   26168 kB
Mon Mar  2 05:29:10 PM UTC 2026,PID 77,VmRSS:	   26232 kB
Mon Mar  2 05:34:10 PM UTC 2026,PID 77,VmRSS:	   30396 kB
Mon Mar  2 05:39:10 PM UTC 2026,PID 77,VmRSS:	   32508 kB
Mon Mar  2 05:44:10 PM UTC 2026,PID 77,VmRSS:	   34620 kB
Mon Mar  2 05:49:10 PM UTC 2026,PID 77,VmRSS:	   34684 kB
Mon Mar  2 05:54:10 PM UTC 2026,PID 77,VmRSS:	   38856 kB
Mon Mar  2 05:59:10 PM UTC 2026,PID 77,VmRSS:	   40968 kB
Mon Mar  2 06:09:10 PM UTC 2026,PID 77,VmRSS:	   43144 kB
```

TopMemoryContext used bytes grows from 4.6 MB (measured 10 minutes after start) to 17.1 MB (measured 42 minutes after start).

```
2026-03-02 17:20:26.499 UTC [77] LOG:  level: 1; TopMemoryContext: 8447104 total in 13 blocks; 3764496 free (33 chunks); 4682608 used
2026-03-02 17:20:26.501 UTC [77] LOG:  Grand total: 10310248 bytes in 264 blocks; 4439144 free (297 chunks); 5871104 used

2026-03-02 17:25:07.921 UTC [77] LOG:  level: 1; TopMemoryContext: 8447104 total in 13 blocks; 1860496 free (33 chunks); 6586608 used
2026-03-02 17:25:07.924 UTC [77] LOG:  Grand total: 10310248 bytes in 264 blocks; 2535144 free (297 chunks); 7775104 used

2026-03-02 17:41:35.908 UTC [77] LOG:  level: 1; TopMemoryContext: 16835712 total in 14 blocks; 3571464 free (34 chunks); 13264248 used
2026-03-02 17:41:35.909 UTC [77] LOG:  Grand total: 18698856 bytes in 265 blocks; 4246112 free (298 chunks); 14452744 used

2026-03-02 17:51:17.491 UTC [77] LOG:  level: 1; TopMemoryContext: 25224320 total in 15 blocks; 8029632 free (36 chunks); 17194688 used
2026-03-02 17:51:17.493 UTC [77] LOG:  Grand total: 27087464 bytes in 266 blocks; 8704280 free (300 chunks); 18383184 used
```

### Branch fix-shm-mq-handle-leak

VmRSS of the pg_cron launcher process grows from 17.6 MB to 18.3 MB over one hour.

```
Mon Mar  2 08:27:10 PM UTC 2026,PID 77,VmRSS:	   17664 kB
Mon Mar  2 08:32:00 PM UTC 2026,PID 77,VmRSS:	   17860 kB
Mon Mar  2 08:37:00 PM UTC 2026,PID 77,VmRSS:	   17924 kB
Mon Mar  2 08:47:00 PM UTC 2026,PID 77,VmRSS:	   18064 kB
Mon Mar  2 08:57:00 PM UTC 2026,PID 77,VmRSS:	   18192 kB
Mon Mar  2 09:19:00 PM UTC 2026,PID 77,VmRSS:	   18256 kB
Mon Mar  2 09:27:00 PM UTC 2026,PID 77,VmRSS:	   18328 kB
```

TopMemoryContext uses exactly 85488 bytes immediately after start and after 1 hour.

```
2026-03-02 20:27:46.676 UTC [77] LOG:  level: 1; TopMemoryContext: 91264 total in 5 blocks; 5776 free (22 chunks); 85488 used
2026-03-02 20:27:46.677 UTC [77] LOG:  Grand total: 1954408 bytes in 256 blocks; 680424 free (286 chunks); 1273984 used

2026-03-02 20:34:47.559 UTC [77] LOG:  level: 1; TopMemoryContext: 91264 total in 5 blocks; 5776 free (22 chunks); 85488 used
2026-03-02 20:34:47.560 UTC [77] LOG:  Grand total: 1954408 bytes in 256 blocks; 680424 free (286 chunks); 1273984 used

2026-03-02 21:32:35.333 UTC [77] LOG:  level: 1; TopMemoryContext: 91264 total in 5 blocks; 5776 free (22 chunks); 85488 used
2026-03-02 21:32:35.335 UTC [77] LOG:  Grand total: 1954408 bytes in 256 blocks; 680424 free (286 chunks); 1273984 used
```

---

When adding the initialization to `InitializeCronTask`, I wondered whether this project would be interested in using C99 designated initializers, so we get automatic zeroing of the rest of the fields:

```c
void
InitializeCronTask(CronTask *task, int64 jobId)
{
    *task = (CronTask){ .jobId = jobId, .state = CRON_TASK_WAITING, .isActive = true };
    // all the other fields are initialized to 0/NULL/false.
}
```

(if yes, it belongs in a separate refactoring PR.)