### PR TITLE
EnsureDeletePermission should not accept case insensitive comparison for the role

### DIFF
--- a/expected/pg_cron-test.out
+++ b/expected/pg_cron-test.out
@@ -264,6 +264,20 @@ SELECT username FROM cron.job where jobid=7;
  pgcron_cront
 (1 row)
 
+-- Make sure ownership checks remain case-sensitive for quoted role names
+CREATE USER "CaseOwner";
+CREATE USER caseowner;
+GRANT USAGE ON SCHEMA cron TO "CaseOwner", caseowner;
+SELECT cron.schedule_in_database(job_name:='mixed case owner', schedule:='0 11 * * *', command:='VACUUM',database:=current_database(), username:='CaseOwner');
+ schedule_in_database 
+----------------------
+                    8
+(1 row)
+
+SET SESSION AUTHORIZATION caseowner;
+SELECT cron.unschedule(8);
+ERROR:  permission denied for table job
+RESET SESSION AUTHORIZATION;
 -- Override function
 DROP EXTENSION IF EXISTS pg_cron cascade;
 CREATE TABLE test (data text);
@@ -339,5 +353,7 @@ HINT:  Use cron format (e.g. 5 4 * * *), or interval format '[1-59] seconds'
 -- cleaning
 DROP EXTENSION pg_cron;
 drop user pgcron_cront;
+drop user "CaseOwner";
+drop user caseowner;
 drop database pgcron_dbno;
 drop database pgcron_dbyes;

--- a/sql/pg_cron-test.sql
+++ b/sql/pg_cron-test.sql
@@ -138,6 +138,17 @@ SELECT username FROM cron.job where jobid=2;
 SELECT cron.schedule_in_database(job_name:='his vacuum', schedule:='0 11 * * *', command:='VACUUM',database:=current_database(), username:='pgcron_cront');
 SELECT username FROM cron.job where jobid=7;
 
+-- Make sure ownership checks remain case-sensitive for quoted role names
+CREATE USER "CaseOwner";
+CREATE USER caseowner;
+GRANT USAGE ON SCHEMA cron TO "CaseOwner", caseowner;
+
+SELECT cron.schedule_in_database(job_name:='mixed case owner', schedule:='0 11 * * *', command:='VACUUM',database:=current_database(), username:='CaseOwner');
+
+SET SESSION AUTHORIZATION caseowner;
+SELECT cron.unschedule(8);
+RESET SESSION AUTHORIZATION;
+
 -- Override function
 DROP EXTENSION IF EXISTS pg_cron cascade;
 CREATE TABLE test (data text);
@@ -172,5 +183,7 @@ SELECT cron.schedule('bad-last-dom-job1', '0 11 $foo * *', 'VACUUM FULL');
 -- cleaning
 DROP EXTENSION pg_cron;
 drop user pgcron_cront;
+drop user "CaseOwner";
+drop user caseowner;
 drop database pgcron_dbno;
 drop database pgcron_dbyes;

--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -757,13 +757,13 @@ EnsureDeletePermission(Relation cronJobsTable, HeapTuple heapTuple)
 
 	/* check if the current user owns the row */
 	Oid userId = GetUserId();
-	char *userName = GetUserNameFromId(userId, false);
 
 	bool isNull = false;
 	Datum ownerNameDatum = heap_getattr(heapTuple, Anum_cron_job_username,
 										tupleDescriptor, &isNull);
 	char *ownerName = TextDatumGetCString(ownerNameDatum);
-	if (pg_strcasecmp(userName, ownerName) != 0)
+	Oid ownerId = get_role_oid(ownerName, true);
+	if (ownerId != userId)
 	{
 		/* otherwise, allow if the user has DELETE permission */
 		AclResult aclResult = pg_class_aclcheck(CronJobRelationId(), GetUserId(),


### PR DESCRIPTION
https://github.com/citusdata/pg_cron/blob/3b9c492d452d4a868512d60c3f8dd7a13b22be3d/src/job_metadata.c#L766 where the "EnsureDeletePermission" uses pg_strcasecmp (case-insensitive) to compare the current user with the job owner. PostgreSQL role names are case-sensitive.