### PR TITLE
Revisions to allow compiling under Windows-mingw64

### DIFF
--- a/include/cron.h
+++ b/include/cron.h
@@ -28,7 +28,43 @@
 
 /* reorder these #include's at your peril */
 
+#ifndef WIN32_COMPAT_H
+#define WIN32_COMPAT_H
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+
+
+
+/* Fix missing POSIX types */
+#ifndef uid_t
+typedef int uid_t;
+typedef int gid_t;
+#endif
+
+#ifndef uint
+typedef unsigned int uint;
+#endif
+
+/* Fix poll mapping */
+#define poll WSAPoll
+
+/* Stub out rlimit to satisfy the compiler without using port.h */
+struct rlimit {
+    uint rlim_cur;
+    uint rlim_max;
+};
+#define RLIMIT_NOFILE 0
+static inline int getrlimit(int resource, struct rlimit *rlp) { return 0; }
+
+#endif /* _WIN32 */
+#endif /* WIN32_COMPAT_H */
+
+
 #include <sys/types.h>
+
+
 #include <sys/param.h>
 
 #include <stdio.h>

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -11,7 +11,19 @@
  *
  *-------------------------------------------------------------------------
  */
+
+/** move this first so windows gets the winsock early */ 
+#include "cron.h"
+
+#if defined(_WIN32) && (PG_VERSION_NUM < 160000)
+/* 
+* Skip sys/resource.h for PG15 and lower on Windows
+* this is only an issue with PG < 16 for windows cause of the changes in 16 and above for windows 
+*/
+#else
 #include <sys/resource.h>
+#endif
+
 
 #include "postgres.h"
 #include "fmgr.h"
@@ -30,7 +42,6 @@
 /* these headers are used by this particular worker's code */
 
 #define MAIN_PROGRAM
-#include "cron.h"
 
 #include "pg_cron.h"
 #include "task_states.h"
@@ -1508,7 +1519,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 			task->lastStartTime = GetCurrentTimestamp();
 
 			if (CronLogRun)
-				UpdateJobRunDetail(task->runId, &pid, GetCronStatus(CRON_STATUS_RUNNING), NULL, &task->lastStartTime, NULL);
+				UpdateJobRunDetail(task->runId, (int32 *) &pid, GetCronStatus(CRON_STATUS_RUNNING), NULL, &task->lastStartTime, NULL);
 
 			task->state = CRON_TASK_BGW_RUNNING;
 			break;
@@ -1556,7 +1567,7 @@ ManageCronTask(CronTask *task, TimestampTz currentTime)
 
 				pid = (pid_t) PQbackendPID(connection);
 				if (CronLogRun)
-					UpdateJobRunDetail(task->runId, &pid, GetCronStatus(CRON_STATUS_SENDING), NULL, NULL, NULL);
+					UpdateJobRunDetail(task->runId, (int32 *) &pid, GetCronStatus(CRON_STATUS_SENDING), NULL, NULL, NULL);
 			}
 			else if (pollingStatus == PGRES_POLLING_FAILED)
 			{


### PR DESCRIPTION
This is to support pg_cron working on windows.

Note I compiled this using msys2-mingw64 but I'm using it under PostgreSQL Windows EDB installs.  Seems to work fine.  I tested with PG 16 and PG18 but made sure it compiled for PG13-PG18.

I had to make additional adjustments for PG < 15 cause I guess they improved windows headers in PG for 16 and above.

I did use Google AI assistant for some guidance.

The (int 32) casting in the UpdateJobRunDetail was needed, because otherwise I was getting an incompatible cast from int32 to pid_t * {aka long long int *}.  I assumed that was better than changing the definition of 

```
 UpdateJobRunDetail(int64 runId, int32 *job_pid, char *status, char *return_message, TimestampTz *start_time,
									TimestampTz *end_time);
```

To 

```
 UpdateJobRunDetail(int64 runId, pid_t *job_pid, char *status, char *return_message, TimestampTz *start_time,
									TimestampTz *end_time);
```

But both variants worked.