### PR TITLE
Use PG_MODULE_MAGIC_EXT

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -109,8 +109,14 @@
 #include "libpq/pqformat.h"
 #include "utils/builtins.h"
 
-
+#if (PG_VERSION_NUM >= 180000)
+PG_MODULE_MAGIC_EXT(
+	.name = "pg_cron",
+	.version = "1.6.7",
+);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 #ifndef MAXINT8LEN
 #define MAXINT8LEN 20


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.