### PR TITLE
feat(win): Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Global excludes across all subdirectories
 *.o
+*.obj
 *.so
 *.so.[0-9]
 *.so.[0-9].[0-9]
@@ -8,6 +9,8 @@
 *.sl.[0-9].[0-9]
 *.dylib
 *.dll
+*.lib
+*.exp
 *.a
 *.mo
 *.pot

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,63 @@
+# src/test/modules/pg_cron/Makefile.win
+
+EXTENSION = pg_cron
+
+DATA_built = $(EXTENSION)--1.0.sql
+
+REGRESS_OPTS = --temp-config=./pg_cron.conf --temp-instance=./tmp_check
+REGRESS = pg_cron-test
+
+OBJS = src/entry.obj src/job_metadata.obj src/misc.obj src/pg_cron.obj src/task_states.obj
+OBJS_CLEAN = src\entry.obj src\job_metadata.obj src\misc.obj src\pg_cron.obj src\task_states.obj
+
+# TODO use pg_config
+!ifndef PGROOT
+!error PGROOT is not set
+!endif
+BINDIR = $(PGROOT)\bin
+INCLUDEDIR = $(PGROOT)\include
+INCLUDEDIR_SERVER = $(PGROOT)\include\server
+LIBDIR = $(PGROOT)\lib
+PKGLIBDIR = $(PGROOT)\lib
+SHAREDIR = $(PGROOT)\share
+
+# Use $(PGROOT)\bin\pg_regress for Postgres < 17
+PG_REGRESS = $(LIBDIR)\pgxs\src\test\regress\pg_regress
+
+CFLAGS = /nologo /DWIN32_NO_STATUS /Dstrcasecmp=_stricmp /I"$(INCLUDEDIR_SERVER)\port\win32_msvc" /I"$(INCLUDEDIR_SERVER)\port\win32" /I"$(INCLUDEDIR_SERVER)" /I"$(INCLUDEDIR)" /Iinclude /Isrc
+
+SHLIB = $(EXTENSION).dll
+
+LIBS = "$(LIBDIR)\postgres.lib" "$(LIBDIR)\libpq.lib" "$(LIBDIR)\libintl.lib" ws2_32.lib
+
+all: $(SHLIB) $(DATA_built)
+
+.c.obj:
+	$(CC) $(CFLAGS) /c $< /Fo$@
+
+$(SHLIB): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) $(LIBS) /link /DLL /OUT:$(SHLIB)
+
+$(EXTENSION)--1.0.sql: $(EXTENSION).sql
+	copy $(EXTENSION).sql $@
+
+install: all
+	if not exist "$(SHAREDIR)\extension" mkdir "$(SHAREDIR)\extension"
+	copy $(EXTENSION).control "$(SHAREDIR)\extension\"
+	copy $(DATA_built) "$(SHAREDIR)\extension\"
+	for %f in ($(EXTENSION)--*--*.sql) do copy "%f" "$(SHAREDIR)\extension\"
+	copy $(SHLIB) "$(PKGLIBDIR)\"
+
+installcheck:
+	"$(PG_REGRESS)" --bindir="$(BINDIR)" $(REGRESS_OPTS) $(REGRESS)
+
+uninstall:
+	del /f "$(PKGLIBDIR)\$(SHLIB)"
+	del /f "$(SHAREDIR)\extension\$(EXTENSION).control"
+	del /f "$(SHAREDIR)\extension\$(EXTENSION)--*.sql"
+
+clean:
+	del /f $(SHLIB) $(EXTENSION).lib $(EXTENSION).exp
+	del /f $(DATA_built)
+	del /f $(OBJS_CLEAN)
+	del /f /s /q results regression.diffs regression.out tmp_check tmp_check_iso log output_iso

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Ensure [C++ support in Visual Studio](https://learn.microsoft.com/en-us/cpp/buil
 ```cmd
 set "PGROOT=C:\Program Files\PostgreSQL\18"
 cd %TMP%
-git clone https://github.com/citusdata/pg_cron
+git clone https://github.com/citusdata/pg_cron.git
 cd pg_cron
 nmake /F Makefile.win
 nmake /F Makefile.win install

--- a/README.md
+++ b/README.md
@@ -296,6 +296,29 @@ export PATH=/usr/pgsql-18/bin:$PATH
 make && sudo PATH=$PATH make install
 ```
 
+## Windows
+
+Ensure [C++ support in Visual Studio](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#download-and-install-the-tools) is installed and run `x64 Native Tools Command Prompt for VS [version]` as administrator. Then use `nmake` to build:
+
+```cmd
+set "PGROOT=C:\Program Files\PostgreSQL\18"
+cd %TMP%
+git clone https://github.com/citusdata/pg_cron
+cd pg_cron
+nmake /F Makefile.win
+nmake /F Makefile.win install
+```
+
+### Installation Notes - Windows
+
+#### Missing Header
+
+If compilation fails with `Cannot open include file: 'postgres.h': No such file or directory`, make sure `PGROOT` is correct.
+
+#### Permissions
+
+If installation fails with `Access is denied`, re-run the installation instructions as an administrator.
+
 # Setting up pg_cron
 
 To start the pg_cron background worker, you need to add pg_cron to `shared_preload_libraries` in postgresql.conf. Note that pg_cron does not run any jobs as a long a server is in [hot standby](https://www.postgresql.org/docs/current/static/hot-standby.html) mode, but it automatically starts when the server is promoted.

--- a/include/cron.h
+++ b/include/cron.h
@@ -192,8 +192,13 @@ typedef int time_min;
 
 typedef	struct _entry {
 	struct _entry	*next;
-	uid_t		uid;	
+    #if defined(_WIN32)
+	unsigned int 	uid;
+	unsigned int 	gid;
+	#else
+	uid_t		uid;
 	gid_t		gid;
+	#endif
 	char		**envp;
 	int         secondsInterval;
 	bitstr_t	bit_decl(minute, MINUTE_COUNT);

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -12,13 +12,13 @@
  *-------------------------------------------------------------------------
  */
 
-/** move this first so windows gets the winsock early */ 
+/** move this first so windows gets the winsock early */
 #include "cron.h"
 
 #if defined(_WIN32) && (PG_VERSION_NUM < 160000)
-/* 
+/*
 * Skip sys/resource.h for PG15 and lower on Windows
-* this is only an issue with PG < 16 for windows cause of the changes in 16 and above for windows 
+* this is only an issue with PG < 16 for windows cause of the changes in 16 and above for windows
 */
 #else
 #include <sys/resource.h>
@@ -52,6 +52,13 @@
 #include <poll.h>
 #elif defined(HAVE_SYS_POLL_H)
 #include <sys/poll.h>
+#endif
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <winsock2.h>
+
+#define poll WSAPoll
 #endif
 
 #include "sys/time.h"
@@ -549,7 +556,12 @@ void
 PgCronLauncherMain(Datum arg)
 {
 	MemoryContext CronLoopContext = NULL;
+
+	#if defined(_WIN32)
+	uint32 maxIoFiles;
+	#else
 	struct rlimit limit;
+	#endif
 
 	/* Establish signal handlers before unblocking signals. */
 	pqsignal(SIGHUP, SignalHandlerForConfigReload);
@@ -586,11 +598,18 @@ PgCronLauncherMain(Datum arg)
 		MaxRunningTasks = max_files_per_process;
 	}
 
+    #if defined(_WIN32)
+    maxIoFiles = (uint32)_getmaxstdio();
+	if (maxIoFiles != 0 && maxIoFiles < (uint32)MaxRunningTasks) {
+		MaxRunningTasks = maxIoFiles;
+	}
+	#else
 	if (getrlimit(RLIMIT_NOFILE, &limit) != 0 &&
 		limit.rlim_cur < (uint32) MaxRunningTasks)
 	{
 		MaxRunningTasks = limit.rlim_cur;
 	}
+	#endif
 
 	if (UseBackgroundWorkers && max_worker_processes - 1 < MaxRunningTasks)
 	{


### PR DESCRIPTION
Inspired by https://github.com/pgvector/pgvector

Tested on Win 11, MSVS 2022 (MSVC 19), built for PostgreSQL 18

P.S. Also tested that it keep working on Ubuntu 24.04, built for PostgreSQL 17 (using clang 19)

P.P.S. Build fails on MINGW 64 for PostgreSQL 17+ but that's out of scope of this PR (its unrelated to changes introduced by this PR):
```
D:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/15.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: src/pg_cron.o:pg_cron.c:(.text+0x158b): undefined reference to `libintl_ngettext'
collect2.exe: error: ld returned 1 exit status
make: *** [D:/msys64/mingw64/lib/postgresql/pgxs/src/makefiles/../../src/Makefile.shlib:319: pg_cron.dll] Error 1
```

But could be easy fixed by patching `Makefile`'s `SHLIB_LINK = $(libpq)` to `SHLIB_LINK = $(libpq) -lintl`

Closes #22
Closes #323 