### PR TITLE
Fix getrlimit return value handling.

### DIFF
--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -609,7 +609,7 @@ PgCronLauncherMain(Datum arg)
 		MaxRunningTasks = max_files_per_process;
 	}
 
-	if (getrlimit(RLIMIT_NOFILE, &limit) != 0 &&
+	if (getrlimit(RLIMIT_NOFILE, &limit) == 0 &&
 		limit.rlim_cur < (uint32) MaxRunningTasks)
 	{
 		MaxRunningTasks = limit.rlim_cur;

--- a/src/pg_cron.c
+++ b/src/pg_cron.c
@@ -622,7 +622,7 @@ PgCronLauncherMain(Datum arg)
 	}
 
 
-  #if defined(_WIN32)
+    #if defined(_WIN32)
     maxIoFiles = (uint32)_getmaxstdio();
 	if (maxIoFiles != 0 && maxIoFiles < (uint32)MaxRunningTasks) {
 		MaxRunningTasks = maxIoFiles;


### PR DESCRIPTION
`getrlimit()` returns 0 on success. Fix the previous logic that incorrectly treated a nonzero return value as success.