### PR TITLE
Add dep to -lintl to compile under mingw64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 ifeq ($(shell uname -s),SunOS)
     PG_CPPFLAGS += -Wno-sign-compare -D__EXTENSIONS__
 endif
-SHLIB_LINK = $(libpq)
+SHLIB_LINK = $(libpq) -lintl
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 
 PG_CONFIG ?= pg_config


### PR DESCRIPTION
As noted by @codercms in https://github.com/citusdata/pg_cron/pull/431

This is to fix mingw64 compile issue that I think got introduced by commit 36f1b33.  I'm guessing the use of gettext in

https://github.com/citusdata/pg_cron/commit/36f1b33fc10feea74ef80e88723a405416bfcaa2#diff-549507abe838afd58ce21e2f275939b50c853dfa939926816506f00bf3fa0544R333-R337