### PR TITLE
Only link -lintl on MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 ifeq ($(shell uname -s),SunOS)
     PG_CPPFLAGS += -Wno-sign-compare -D__EXTENSIONS__
 endif
-SHLIB_LINK = $(libpq) -lintl
+SHLIB_LINK = $(libpq)
 EXTRA_CLEAN += $(addprefix src/,*.gcno *.gcda) # clean up after profiling runs
 
 PG_CONFIG ?= pg_config


### PR DESCRIPTION
Commit d1f714f ("Add dep to -lintl to compile under mingw64") added `-lintl` unconditionally to `SHLIB_LINK`. On glibc-based Linux systems the gettext functions are provided by libc itself and there is no separate libintl.so, so every Linux build now fails at link time with:

```
    /usr/bin/ld: cannot find -lintl: No such file or directory
```

Windows builds are served by the dedicated `Makefile.win`, which already links libintl explicitly, so the PGXS `Makefile` does not need to carry the flag. Remove it to restore the previous behaviour on all other platforms.