### PR TITLE
Reject duplicate jobId entries in TupleToCronJob

### DIFF
--- a/src/job_metadata.c
+++ b/src/job_metadata.c
@@ -972,7 +972,13 @@ TupleToCronJob(TupleDesc tupleDescriptor, HeapTuple heapTuple)
 	}
 
 	job = hash_search(CronJobHash, &jobKey, HASH_ENTER, &isPresent);
-
+	if (isPresent)
+	{
+		ereport(WARNING, (errcode(ERRCODE_DATA_CORRUPTED),
+						  errmsg("skipping duplicate entry for job " INT64_FORMAT,
+								 jobKey)));
+		return NULL;
+	}
 	job->jobId = DatumGetInt64(jobId);
 	job->scheduleText = TextDatumGetCString(schedule);
 	job->command = TextDatumGetCString(command);


### PR DESCRIPTION
Prevent duplicate `cron.job` records (e.g. from a dropped primary key) from overwriting existing in-memory entries in `CronJobHash` during metadata scans. When a duplicate `jobid` is encountered during `TupleToCronJob`, log a warning and discard the duplicate instead of overwriting the previous entry.
